### PR TITLE
Migration  to Choco 3.3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@ javadoc:
 jacoco:
 	mvn org.jacoco:jacoco-maven-plugin:prepare-agent test org.jacoco:jacoco-maven-plugin:report
 	@echo "Developer note: firefox target/site/jacoco/index.html"
-	
+
 clean:
 	mvn clean
 
-install:  
+install:
 	mkdir -p $(to)
 	cp -f README.md $(to)/chocosolver-README.md
-	cp -f target/chocosolver-0.3.7-jar-with-dependencies.jar $(to)/chocosolver.jar
+	cp -f target/chocosolver-0.3.8-jar-with-dependencies.jar $(to)/chocosolver.jar

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 chocosolver
 ===========
 
-v0.3.7
+v0.3.8
 
 A backend for [Clafer](http://clafer.org) using the Choco 3 constraint programming library. There are two ways to use the project: programmatically via the Java API, or the Javascript CLI.
 
@@ -16,7 +16,7 @@ Getting Clafer Tools
 
 ### Installation from binaries
 
-Binary distributions of the release 0.3.7 of Clafer Tools for Windows, Mac, and Linux, can be downloaded from [Clafer Tools - Binary Distributions](http://http://gsd.uwaterloo.ca/clafer-tools-binary-distributions). 
+Binary distributions of the release 0.3.8 of Clafer Tools for Windows, Mac, and Linux, can be downloaded from [Clafer Tools - Binary Distributions](http://http://gsd.uwaterloo.ca/clafer-tools-binary-distributions). 
 
 1. download the binaries and unpack `<target directory>` of your choice
 2. add the `<target directory>` to your system path so that the executables can be found
@@ -31,7 +31,7 @@ Prerequisites
 
 Optional
 --------
-* [Clafer compiler](https://github.com/gsdlab/clafer) - This backend provides an API for solving Clafer models. The Clafer compiler can compile a Clafer model down to the proper API calls. Can also be done manually by hand quite easily with a bit of typing (examples down below). v0.3.7.
+* [Clafer compiler](https://github.com/gsdlab/clafer) - This backend provides an API for solving Clafer models. The Clafer compiler can compile a Clafer model down to the proper API calls. Can also be done manually by hand quite easily with a bit of typing (examples down below). v0.3.8.
 
 Follow the installation instructions in the [README.md](https://github.com/gsdlab/clafer#clafer).
 
@@ -51,10 +51,10 @@ Include the following XML snippet in your POM to use the API in your Maven proje
 <dependency>
     <groupId>org.clafer</groupId>
     <artifactId>chocosolver</artifactId>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
 </dependency>
 ```
-The CLI is installed to target/chocosolver-0.3.7-jar-with-dependencies.jar. Start the CLI using the command "java -jar chocosolver-0.3.7-jar-with-dependencies.jar mymodel.js".
+The CLI is installed to target/chocosolver-0.3.8-jar-with-dependencies.jar. Start the CLI using the command "java -jar chocosolver-0.3.8-jar-with-dependencies.jar mymodel.js".
 
 ### Important: Branches must correspond
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 
     <groupId>org.clafer</groupId>
     <artifactId>chocosolver</artifactId>
-    <version>0.3.7</version>
+    <version>0.3.8</version>
     <packaging>jar</packaging>
 
     <name>chocosolver</name>
     <url>http://github.com/gsdlab/chocosolver</url>
     <description>A backend for Clafer based on the Choco 3 constraint programming library.</description>
-    
+
     <developers>
         <developer>
             <name>Jimmy Liang</name>
@@ -25,9 +25,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>choco</groupId>
+            <groupId>org.choco-solver</groupId>
             <artifactId>choco-solver</artifactId>
-            <version>3.2.3-SNAPSHOT</version>
+            <version>3.3.0</version>
         </dependency>
         <dependency>
             <groupId>org.mozilla</groupId>
@@ -47,15 +47,7 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    
-    <repositories>
-        <repository>
-            <id>choco.repos</id>
-            <url>http://www.emn.fr/z-info/choco-repo/mvn/repository/</url>
-        </repository>
-    </repositories>
 
-    
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/move322to330.sh
+++ b/src/main/java/move322to330.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package samples%package org\.chocosolver\.samples%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package solver%package org\.chocosolver\.solver%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package memory%package org\.chocosolver\.memory%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package util%package org\.chocosolver\.util%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package docs%package org\.chocosolver\.docs%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%package choco%package org\.chocosolver\.choco%g"
+
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import solver%import org\.chocosolver\.solver%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import samples%import org\.chocosolver\.samples%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import memory%import org\.chocosolver\.memory%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import util%import org\.chocosolver\.util%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import choco%import org\.chocosolver\.choco%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import static solver%import static org\.chocosolver\.solver%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import static samples%import static org\.chocosolver\.samples%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import static util%import static org\.chocosolver\.util%g"
+find . -type f -name *.java -print0 | xargs -0 sed -i '' "s%import static choco%import static org\.chocosolver\.choco%g"

--- a/src/main/java/org/chocosolver/solver/variables/CSetVar.java
+++ b/src/main/java/org/chocosolver/solver/variables/CSetVar.java
@@ -1,6 +1,8 @@
-package solver.variables;
+package org.chocosolver.solver.variables;
 
-import solver.constraints.set.SCF;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/main/java/org/chocosolver/solver/variables/CStringVar.java
+++ b/src/main/java/org/chocosolver/solver/variables/CStringVar.java
@@ -1,8 +1,9 @@
-package solver.variables;
+package org.chocosolver.solver.variables;
 
 import java.util.Arrays;
 import org.clafer.choco.constraint.Constraints;
-import solver.variables.IntVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/main/java/org/chocosolver/solver/variables/Var.java
+++ b/src/main/java/org/chocosolver/solver/variables/Var.java
@@ -1,15 +1,18 @@
-package solver.variables;
+package org.chocosolver.solver.variables;
 
 import java.util.Arrays;
 import org.clafer.choco.constraint.Constraints;
 import org.clafer.common.Util;
-import solver.Solver;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.VariableFactory;
 
 /**
  *
  * @author jimmy
  */
-public class Var extends solver.variables.VariableFactory {
+public class Var extends VariableFactory {
 
     public static int[] dom(int... doms) {
         return doms;

--- a/src/main/java/org/clafer/choco/constraint/Constraints.java
+++ b/src/main/java/org/clafer/choco/constraint/Constraints.java
@@ -12,7 +12,7 @@ import org.clafer.choco.constraint.propagator.PropAtMostTransitiveClosure;
 import org.clafer.choco.constraint.propagator.PropContinuous;
 import org.clafer.choco.constraint.propagator.PropContinuousUnion;
 import org.clafer.choco.constraint.propagator.PropCountNotEqual;
-import org.clafer.choco.constraint.propagator.PropElement;
+//import org.clafer.choco.constraint.propagator.PropElement;
 import org.clafer.choco.constraint.propagator.PropEqualXY_Z;
 import org.clafer.choco.constraint.propagator.PropFilterString;
 import org.clafer.choco.constraint.propagator.PropIfThenElse;
@@ -48,27 +48,27 @@ import org.clafer.choco.constraint.propagator.PropTransitiveUnreachable;
 import org.clafer.choco.constraint.propagator.PropUnreachable;
 import org.clafer.collection.Maybe;
 import org.clafer.common.Util;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.constraints.Propagator;
-import solver.constraints.binary.PropEqualXY_C;
-import solver.constraints.binary.PropEqualX_Y;
-import solver.constraints.binary.PropEqualX_YC;
-import solver.constraints.binary.PropGreaterOrEqualX_Y;
-import solver.constraints.nary.element.PropElementV_fast;
-import solver.constraints.nary.sum.PropSumEq;
-import solver.constraints.set.PropElement;
-import solver.constraints.set.PropIntersection;
-import solver.constraints.set.PropSubsetEq;
-import solver.constraints.unary.PropEqualXC;
-import solver.constraints.unary.PropGreaterOrEqualXC;
-import solver.constraints.unary.PropLessOrEqualXC;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.VF;
-import solver.variables.Variable;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.binary.PropEqualXY_C;
+import org.chocosolver.solver.constraints.binary.PropEqualX_Y;
+import org.chocosolver.solver.constraints.binary.PropEqualX_YC;
+import org.chocosolver.solver.constraints.binary.PropGreaterOrEqualX_Y;
+import org.chocosolver.solver.constraints.nary.element.PropElementV_fast;
+import org.chocosolver.solver.constraints.nary.sum.PropSumEq;
+import org.chocosolver.solver.constraints.set.PropElement;
+import org.chocosolver.solver.constraints.set.PropIntersection;
+import org.chocosolver.solver.constraints.set.PropSubsetEq;
+import org.chocosolver.solver.constraints.unary.PropEqualXC;
+import org.chocosolver.solver.constraints.unary.PropGreaterOrEqualXC;
+import org.chocosolver.solver.constraints.unary.PropLessOrEqualXC;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.VF;
+import org.chocosolver.solver.variables.Variable;
 
 /**
  * Custom Choco constraints. Designed for Clafer. Note that these constraints
@@ -372,7 +372,7 @@ public class Constraints {
     }
 
     public static Constraint element(IntVar value, IntVar[] array, IntVar index, int offset) {
-        return new Constraint("element", new PropElement(value, array, index, offset));
+        return new Constraint("element", new org.clafer.choco.constraint.propagator.PropElement(value, array, index, offset));
     }
 
     /**
@@ -427,7 +427,7 @@ public class Constraints {
      * @return constraint {@code x ∈ sets[i] <=> ints[x] = i}
      */
     public static Constraint intChannel(SetVar[] sets, IntVar[] ints) {
-        /* 
+        /*
          * TODO: Take cardinalities of the sets into account?
          * For example if card(sets[0]) <= 3, then if at least 3 of the integers
          * are instantiated to 0, then remove 0 from the domains of the other integers.
@@ -865,8 +865,8 @@ public class Constraints {
             throw new IllegalArgumentException();
         }
         return new Constraint("element",
-                new solver.constraints.set.PropElement(index, array, 0, value),
-                new solver.constraints.set.PropElement(index, array, 0, value),
+                new org.chocosolver.solver.constraints.set.PropElement(index, array, 0, value),
+                new org.chocosolver.solver.constraints.set.PropElement(index, array, 0, value),
                 new PropElementV_fast(valueCard, arrayCards, index, 0, true),
                 new PropElementV_fast(valueCard, arrayCards, index, 0, true));
     }

--- a/src/main/java/org/clafer/choco/constraint/OrConstraint.java
+++ b/src/main/java/org/clafer/choco/constraint/OrConstraint.java
@@ -3,14 +3,14 @@ package org.clafer.choco.constraint;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-import solver.constraints.Constraint;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.Variable;
-import util.ESat;
-import static util.ESat.TRUE;
-import static util.ESat.UNDEFINED;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.util.ESat;
+import static org.chocosolver.util.ESat.TRUE;
+import static org.chocosolver.util.ESat.UNDEFINED;
 
 /**
  * Boolean or. The difference between this constraint and the one provided by

--- a/src/main/java/org/clafer/choco/constraint/ReifyEqualXC.java
+++ b/src/main/java/org/clafer/choco/constraint/ReifyEqualXC.java
@@ -1,9 +1,9 @@
 package org.clafer.choco.constraint;
 
 import org.clafer.choco.constraint.propagator.PropReifyEqualXC;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/ReifyEqualXY.java
+++ b/src/main/java/org/clafer/choco/constraint/ReifyEqualXY.java
@@ -1,9 +1,9 @@
 package org.clafer.choco.constraint;
 
 import org.clafer.choco.constraint.propagator.PropReifyEqualXY;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/SetEquality.java
+++ b/src/main/java/org/clafer/choco/constraint/SetEquality.java
@@ -2,11 +2,11 @@ package org.clafer.choco.constraint;
 
 import org.clafer.choco.constraint.propagator.PropSetEqual;
 import org.clafer.choco.constraint.propagator.PropSetNotEqual;
-import solver.constraints.Constraint;
-import solver.constraints.Propagator;
-import solver.constraints.binary.PropEqualX_Y;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.binary.PropEqualX_Y;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/SetMember.java
+++ b/src/main/java/org/clafer/choco/constraint/SetMember.java
@@ -1,9 +1,9 @@
 package org.clafer.choco.constraint;
 
-import solver.constraints.Constraint;
-import solver.constraints.set.PropIntMemberSet;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.set.PropIntEnumMemberSet;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *
@@ -15,7 +15,7 @@ public class SetMember extends Constraint {
     private final SetVar set;
 
     public SetMember(IntVar integer, SetVar set) {
-        super("SetMember", new PropIntMemberSet(set, integer));
+        super("SetMember", new PropIntEnumMemberSet(set, integer));
         this.integer = integer;
         this.set = set;
     }

--- a/src/main/java/org/clafer/choco/constraint/SetNotMember.java
+++ b/src/main/java/org/clafer/choco/constraint/SetNotMember.java
@@ -1,9 +1,9 @@
 package org.clafer.choco.constraint;
 
 import org.clafer.choco.constraint.propagator.PropIntNotMemberSet;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropAcyclic.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropAcyclic.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import memory.IStateInt;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.memory.IStateInt;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * Enforce no cycles.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropAnd.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropAnd.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSet.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSet.java
@@ -1,18 +1,18 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSetCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSetCard.java
@@ -3,13 +3,13 @@ package org.clafer.choco.constraint.propagator;
 import gnu.trove.iterator.TIntIntIterator;
 import gnu.trove.map.hash.TIntIntHashMap;
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropAtMostTransitiveClosure.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropAtMostTransitiveClosure.java
@@ -11,11 +11,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.clafer.collection.Counter;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropContinuous.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropContinuous.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropContinuousUnion.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropContinuousUnion.java
@@ -1,16 +1,16 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropCountNotEqual.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropCountNotEqual.java
@@ -1,17 +1,17 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import memory.IEnvironment;
+import org.chocosolver.memory.IEnvironment;
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
-import util.objects.setDataStructures.ISet;
-import util.objects.setDataStructures.SetFactory;
-import util.objects.setDataStructures.SetType;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.objects.setDataStructures.ISet;
+import org.chocosolver.util.objects.setDataStructures.SetFactory;
+import org.chocosolver.util.objects.setDataStructures.SetType;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropElement.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropElement.java
@@ -2,14 +2,14 @@ package org.clafer.choco.constraint.propagator;
 
 import gnu.trove.map.hash.TIntIntHashMap;
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.events.IntEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropEqualXY_Z.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropEqualXY_Z.java
@@ -1,11 +1,11 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * {@code x + y = z}

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropFilterString.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropFilterString.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * result = [string !! i | i <- set].

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropIfThenElse.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropIfThenElse.java
@@ -1,11 +1,11 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropIntChannel.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropIntChannel.java
@@ -1,18 +1,18 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * An idempotent and more efficient propagator than the default one. Does not

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropIntMemberNonemptySet.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropIntMemberNonemptySet.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropIntNotMemberSet.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropIntNotMemberSet.java
@@ -1,20 +1,20 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * Missing from the library.
- * 
+ *
  * @author jimmy
  */
 public class PropIntNotMemberSet extends Propagator<Variable> {

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunction.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunction.java
@@ -3,20 +3,20 @@ package org.clafer.choco.constraint.propagator;
 import gnu.trove.iterator.TIntIterator;
 import gnu.trove.list.array.TIntArrayList;
 import java.util.Arrays;
-import memory.structure.IndexedBipartiteSet;
+import org.chocosolver.memory.structure.IndexedBipartiteSet;
 import org.clafer.collection.MutableBoolean;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * <p>

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunctionCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunctionCard.java
@@ -3,15 +3,15 @@ package org.clafer.choco.constraint.propagator;
 import gnu.trove.iterator.TIntIntIterator;
 import gnu.trove.map.hash.TIntIntHashMap;
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinInjectiveRelationCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinInjectiveRelationCard.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinRelation.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinRelation.java
@@ -3,15 +3,15 @@ package org.clafer.choco.constraint.propagator;
 import gnu.trove.iterator.TIntIterator;
 import gnu.trove.list.array.TIntArrayList;
 import java.util.Arrays;
-import memory.structure.IndexedBipartiteSet;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.memory.structure.IndexedBipartiteSet;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * <p>

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropLength.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropLength.java
@@ -2,12 +2,12 @@ package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropLexChainChannel.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropLexChainChannel.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * strings[i] &lt; strings[j] iff ints[i] &lt;= ints[j] strings[i] = strings[j]

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropLone.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropLone.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropMask.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropMask.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropNotEqualXY_Z.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropNotEqualXY_Z.java
@@ -1,11 +1,11 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * {@code x + y ≠ z}

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropOne.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropOne.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropOr.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropOr.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropReflexive.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropReflexive.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropReifyEqualXC.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropReifyEqualXC.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * (reify = reifyC) <=> (x = c)

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropReifyEqualXY.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropReifyEqualXY.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.events.IntEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * (reify = reifyC) <=> (x = y)

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSamePrefix.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSamePrefix.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSelectN.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSelectN.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * The first n booleans are the true, the rest are false.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetBounded.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetBounded.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.constraint.propagator;
 
-import memory.IStateInt;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.memory.IStateInt;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetDifference.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetDifference.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Check;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetEqual.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetEqual.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * More efficient than the provided PropAllEqual.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetLowBound.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetLowBound.java
@@ -1,16 +1,16 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetMax.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetMax.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * The largest element in the set. Does nothing if the set is empty.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetMin.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetMin.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * The smallest element in the set. Does nothing if the set is empty.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetNotEqual.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetNotEqual.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * More efficient than the provided PropAllDiff. Idempotent unlike the

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetNotEqualC.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetNotEqualC.java
@@ -2,14 +2,14 @@ package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetStrictHighBound.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetStrictHighBound.java
@@ -1,17 +1,17 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.Configuration;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.Settings;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * {@code i ∈ set ⇒ i < bound}

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetSum.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetSum.java
@@ -2,15 +2,15 @@ package org.clafer.choco.constraint.propagator;
 
 import org.clafer.collection.Triple;
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * Sums a set and |set| &le n. This implementation <b>assumes</b> that the

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetUnion.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetUnion.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.constraint.propagator;
 
 import org.clafer.common.Util;
-import solver.ICause;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  * Idempotent version of the one provided by the Choco library.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSetUnionCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSetUnionCard.java
@@ -2,12 +2,12 @@ package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
 import org.clafer.common.Util;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSingleton.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSingleton.java
@@ -1,17 +1,17 @@
 package org.clafer.choco.constraint.propagator;
 
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSortedSets.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSortedSets.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropSortedSetsCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropSortedSetsCard.java
@@ -2,18 +2,18 @@ package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
 import org.clafer.choco.constraint.Constraints;
-import solver.Solver;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.constraints.set.SCF;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.VF;
-import solver.variables.Variable;
-import solver.variables.events.IntEventType;
-import solver.variables.events.SetEventType;
-import util.ESat;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.VF;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropTransitive.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropTransitive.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropTransitiveUnreachable.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropTransitiveUnreachable.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.SetVar;
-import solver.variables.delta.ISetDeltaMonitor;
-import solver.variables.events.SetEventType;
-import util.ESat;
-import util.procedure.IntProcedure;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.variables.events.SetEventType;
+import org.chocosolver.util.ESat;
+import org.chocosolver.util.procedure.IntProcedure;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropUnreachable.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropUnreachable.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint.propagator;
 
 import java.util.Arrays;
-import memory.IStateInt;
-import memory.IStateIntVector;
-import solver.constraints.Propagator;
-import solver.constraints.PropagatorPriority;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.events.IntEventType;
-import util.ESat;
+import org.chocosolver.memory.IStateInt;
+import org.chocosolver.memory.IStateIntVector;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.constraints.PropagatorPriority;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.events.IntEventType;
+import org.chocosolver.util.ESat;
 
 /**
  * Enforces no path from one node to another.

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropUtil.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropUtil.java
@@ -1,12 +1,12 @@
 package org.clafer.choco.constraint.propagator;
 
 import gnu.trove.set.TIntSet;
-import solver.ICause;
-import solver.exception.ContradictionException;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.delta.IIntDeltaMonitor;
-import solver.variables.delta.ISetDeltaMonitor;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.delta.IIntDeltaMonitor;
+import org.chocosolver.solver.variables.delta.ISetDeltaMonitor;
 
 /**
  * Various static utility functions for writing Choco propagators.

--- a/src/main/java/org/clafer/choco/search/RandomSetDecisionStrategy.java
+++ b/src/main/java/org/clafer/choco/search/RandomSetDecisionStrategy.java
@@ -1,15 +1,15 @@
 package org.clafer.choco.search;
 
 import java.util.Random;
-import solver.exception.ContradictionException;
-import solver.search.strategy.assignments.DecisionOperator;
-import solver.search.strategy.decision.Decision;
-import solver.search.strategy.decision.fast.FastDecisionSet;
-import solver.search.strategy.selectors.SetValueSelector;
-import solver.search.strategy.selectors.VariableSelector;
-import solver.search.strategy.strategy.AbstractStrategy;
-import solver.variables.SetVar;
-import util.PoolManager;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.strategy.assignments.DecisionOperator;
+import org.chocosolver.solver.search.strategy.decision.Decision;
+import org.chocosolver.solver.search.strategy.decision.fast.FastDecisionSet;
+import org.chocosolver.solver.search.strategy.selectors.SetValueSelector;
+import org.chocosolver.solver.search.strategy.selectors.VariableSelector;
+import org.chocosolver.solver.search.strategy.strategy.AbstractStrategy;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.util.PoolManager;
 
 /**
  *

--- a/src/main/java/org/clafer/choco/search/RandomSetValueSelector.java
+++ b/src/main/java/org/clafer/choco/search/RandomSetValueSelector.java
@@ -1,8 +1,8 @@
 package org.clafer.choco.search;
 
 import java.util.Random;
-import solver.search.strategy.selectors.SetValueSelector;
-import solver.variables.SetVar;
+import org.chocosolver.solver.search.strategy.selectors.SetValueSelector;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/main/java/org/clafer/common/Util.java
+++ b/src/main/java/org/clafer/common/Util.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import util.iterators.IntIterator;
+import org.chocosolver.util.iterators.IntIterator;
 
 /**
  * Various static utility functions.

--- a/src/main/java/org/clafer/compiler/ClaferCompiler.java
+++ b/src/main/java/org/clafer/compiler/ClaferCompiler.java
@@ -33,14 +33,14 @@ import org.clafer.ir.compiler.IrCompiler;
 import org.clafer.ir.compiler.IrSolutionMap;
 import org.clafer.objective.Objective;
 import org.clafer.scope.Scopable;
-import solver.Solver;
-import solver.search.limits.FailCounter;
-import solver.search.loop.monitors.SMF;
-import solver.search.strategy.IntStrategyFactory;
-import solver.search.strategy.SetStrategyFactory;
-import solver.search.strategy.strategy.AbstractStrategy;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.search.limits.FailCounter;
+import org.chocosolver.solver.search.loop.monitors.SMF;
+import org.chocosolver.solver.search.strategy.IntStrategyFactory;
+import org.chocosolver.solver.search.strategy.SetStrategyFactory;
+import org.chocosolver.solver.search.strategy.strategy.AbstractStrategy;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  * Compiles from AST -> Choco
@@ -145,7 +145,7 @@ public class ClaferCompiler {
                 Random rand = new Random();
                 return Maybe.<AbstractStrategy<?>>just(new RandomSetDecisionStrategy(
                         vars,
-                        new solver.search.strategy.selectors.variables.Random<SetVar>(System.nanoTime()),
+                        new org.chocosolver.solver.search.strategy.selectors.variables.Random<SetVar>(System.nanoTime()),
                         new RandomSetValueSelector(rand), rand));
             default:
                 throw new IllegalStateException("Unknown strategy: " + options.getStrategy());

--- a/src/main/java/org/clafer/compiler/ClaferMultiObjectiveOptimizerGIA.java
+++ b/src/main/java/org/clafer/compiler/ClaferMultiObjectiveOptimizerGIA.java
@@ -5,12 +5,12 @@ import java.util.List;
 import org.clafer.collection.Either;
 import org.clafer.common.Check;
 import org.clafer.instance.InstanceModel;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.constraints.LCF;
-import solver.search.strategy.ISF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.LCF;
+import org.chocosolver.solver.search.strategy.ISF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  * Implementation of the guided improvement algorithm.

--- a/src/main/java/org/clafer/compiler/ClaferSearch.java
+++ b/src/main/java/org/clafer/compiler/ClaferSearch.java
@@ -1,7 +1,7 @@
 package org.clafer.compiler;
 
 import org.clafer.instance.InstanceModel;
-import solver.Solver;
+import org.chocosolver.solver.Solver;
 
 /**
  * Search for instances.

--- a/src/main/java/org/clafer/compiler/ClaferSingleObjectiveOptimizer.java
+++ b/src/main/java/org/clafer/compiler/ClaferSingleObjectiveOptimizer.java
@@ -6,18 +6,18 @@ import java.util.List;
 import org.clafer.collection.Either;
 import org.clafer.common.Check;
 import org.clafer.instance.InstanceModel;
-import solver.ResolutionPolicy;
-import solver.Solver;
-import solver.constraints.ICF;
-import solver.exception.ContradictionException;
-import solver.objective.ObjectiveManager;
-import solver.propagation.NoPropagationEngine;
-import solver.propagation.hardcoded.SevenQueuesPropagatorEngine;
-import solver.search.loop.monitors.IMonitorSolution;
-import solver.search.solution.Solution;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Variable;
+import org.chocosolver.solver.ResolutionPolicy;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.objective.ObjectiveManager;
+import org.chocosolver.solver.propagation.NoPropagationEngine;
+import org.chocosolver.solver.propagation.hardcoded.SevenQueuesPropagatorEngine;
+import org.chocosolver.solver.search.loop.monitors.IMonitorSolution;
+import org.chocosolver.solver.search.solution.Solution;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Variable;
 
 /**
  *

--- a/src/main/java/org/clafer/compiler/ClaferSolver.java
+++ b/src/main/java/org/clafer/compiler/ClaferSolver.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.clafer.common.Check;
 import org.clafer.instance.InstanceModel;
-import solver.Solver;
+import org.chocosolver.solver.Solver;
 
 /**
  *

--- a/src/main/java/org/clafer/compiler/ClaferUnsat.java
+++ b/src/main/java/org/clafer/compiler/ClaferUnsat.java
@@ -12,12 +12,12 @@ import org.clafer.collection.Pair;
 import org.clafer.common.Check;
 import org.clafer.instance.InstanceModel;
 import org.clafer.ir.IrBoolVar;
-import solver.ResolutionPolicy;
-import solver.Solver;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import util.ESat;
+import org.chocosolver.solver.ResolutionPolicy;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.util.ESat;
 
 /**
  * Either call {@link #minUnsat()} xor {@link #unsatCore()} at most once. If you

--- a/src/main/java/org/clafer/compiler/ClaferUnsatOptimizer.java
+++ b/src/main/java/org/clafer/compiler/ClaferUnsatOptimizer.java
@@ -1,7 +1,7 @@
 package org.clafer.compiler;
 
 import org.clafer.instance.InstanceModel;
-import solver.Solver;
+import org.chocosolver.solver.Solver;
 
 /**
  *

--- a/src/main/java/org/clafer/ir/compiler/IrCompiler.java
+++ b/src/main/java/org/clafer/ir/compiler/IrCompiler.java
@@ -100,17 +100,17 @@ import org.clafer.ir.analysis.CommonSubexpression;
 import org.clafer.ir.analysis.DuplicateConstraints;
 import org.clafer.ir.analysis.LinearEquationOptimizer;
 import org.clafer.ir.analysis.Optimizer;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.constraints.Operator;
-import solver.constraints.set.SCF;
-import solver.variables.BoolVar;
-import solver.variables.CSetVar;
-import solver.variables.CStringVar;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.Operator;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CStringVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  * Compile from IR to Choco.

--- a/src/main/java/org/clafer/ir/compiler/IrSolutionMap.java
+++ b/src/main/java/org/clafer/ir/compiler/IrSolutionMap.java
@@ -9,9 +9,9 @@ import org.clafer.ir.IrIntVar;
 import org.clafer.ir.IrSetConstant;
 import org.clafer.ir.IrSetVar;
 import org.clafer.ir.IrStringVar;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  * Maps IR non-constant variables to their translated Choco variables. IR

--- a/src/test/java/org/clafer/choco/constraint/AcyclicTest.java
+++ b/src/test/java/org/clafer/choco/constraint/AcyclicTest.java
@@ -8,10 +8,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/AndTest.java
+++ b/src/test/java/org/clafer/choco/constraint/AndTest.java
@@ -6,10 +6,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ArcConsistentCheck.java
+++ b/src/test/java/org/clafer/choco/constraint/ArcConsistentCheck.java
@@ -1,10 +1,10 @@
 package org.clafer.choco.constraint;
 
-import solver.Solver;
-import solver.exception.ContradictionException;
-import solver.search.loop.monitors.IMonitorContradiction;
-import solver.search.loop.monitors.IMonitorDownBranch;
-import solver.variables.Variable;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.search.loop.monitors.IMonitorContradiction;
+import org.chocosolver.solver.search.loop.monitors.IMonitorDownBranch;
+import org.chocosolver.solver.variables.Variable;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ArrayToSetTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ArrayToSetTest.java
@@ -5,14 +5,14 @@ import gnu.trove.set.TIntSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import org.clafer.common.Util;
 import org.clafer.test.NonEmpty;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -36,7 +36,7 @@ public class ArrayToSetTest {
         /*
          * isUnique [] = True
          * isUnique (x : xs) = x `notElem` xs && isUnique xs
-         * 
+         *
          * solutions =  filter isUnique $ sequence $ replicate 3 [0..5]
          */
         return $(enumeratedArray("array", 3, 0, 5, solver),

--- a/src/test/java/org/clafer/choco/constraint/ConcatTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ConcatTest.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.variables.CStringVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ConstraintQuickTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ConstraintQuickTest.java
@@ -18,9 +18,9 @@ import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
-import solver.Solver;
-import solver.constraints.Constraint;
-import util.ESat;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.util.ESat;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/CountNotEqualTest.java
+++ b/src/test/java/org/clafer/choco/constraint/CountNotEqualTest.java
@@ -4,10 +4,10 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ElementTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ElementTest.java
@@ -7,10 +7,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.VariableFactory.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.VariableFactory.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/EqualXY_ZTest.java
+++ b/src/test/java/org/clafer/choco/constraint/EqualXY_ZTest.java
@@ -4,8 +4,8 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Check;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/FilterStringTest.java
+++ b/src/test/java/org/clafer/choco/constraint/FilterStringTest.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -21,14 +21,14 @@ public class FilterStringTest {
     public Object testFilterString(Solver solver) {
         /*
          * import Control.Monad
-         * 
+         *
          * powerset = filterM (const [True, False])
-         * 
+         *
          * solutions = do
          *     set <- powerset [0..2]
          *     string <- sequence $ replicate 3 [0..2]
          *     let result = [string !! i | i <- set]
-         * 
+         *
          *     return (set, string, result)
          */
         return $(cset("set", 0, 2, solver),

--- a/src/test/java/org/clafer/choco/constraint/IfThenElseTest.java
+++ b/src/test/java/org/clafer/choco/constraint/IfThenElseTest.java
@@ -4,10 +4,10 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/IntChannelTest.java
+++ b/src/test/java/org/clafer/choco/constraint/IntChannelTest.java
@@ -6,11 +6,11 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/JoinFunctionTest.java
+++ b/src/test/java/org/clafer/choco/constraint/JoinFunctionTest.java
@@ -6,14 +6,14 @@ import gnu.trove.set.hash.TIntHashSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import org.clafer.common.Util;
 import org.clafer.test.Positive;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -72,7 +72,7 @@ public class JoinFunctionTest {
          *
          * powerset = filterM (const [True, False])
          *
-         * is2Unique = all ((<= 2) . length) . group . sort 
+         * is2Unique = all ((<= 2) . length) . group . sort
          *
          * solutions = do
          *     from <- powerset [0..2]

--- a/src/test/java/org/clafer/choco/constraint/JoinRelationTest.java
+++ b/src/test/java/org/clafer/choco/constraint/JoinRelationTest.java
@@ -4,13 +4,13 @@ import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import org.clafer.test.Positive;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/LengthTest.java
+++ b/src/test/java/org/clafer/choco/constraint/LengthTest.java
@@ -4,10 +4,10 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/LexChainChannelTest.java
+++ b/src/test/java/org/clafer/choco/constraint/LexChainChannelTest.java
@@ -9,10 +9,10 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -25,7 +25,7 @@ public class LexChainChannelTest {
     public Object testLexChainChannel(Solver solver) {
         /*
          * import Control.Monad
-         * 
+         *
          * solutions = do
          *     string0 <- sequence $ replicate 2 [0..2]
          *     string1 <- sequence $ replicate 2 [0..2]
@@ -33,13 +33,13 @@ public class LexChainChannelTest {
          *     int0 <- [0..2]
          *     int1 <- [0..2]
          *     int2 <- [0..2]
-         * 
+         *
          *     guard $ sort (nub [int0, int1, int2]) `isPrefixOf` [0,1,2]
-         * 
+         *
          *     guard $ compare string0 string1 == compare int0 int1
          *     guard $ compare string0 string2 == compare int0 int2
          *     guard $ compare string1 string2 == compare int1 int2
-         *     
+         *
          *     return (string0, string1, string2, int0, int1, int2)
          */
         IntVar[][] strings = new IntVar[3][];

--- a/src/test/java/org/clafer/choco/constraint/LoneTest.java
+++ b/src/test/java/org/clafer/choco/constraint/LoneTest.java
@@ -6,10 +6,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/MaskTest.java
+++ b/src/test/java/org/clafer/choco/constraint/MaskTest.java
@@ -2,14 +2,14 @@ package org.clafer.choco.constraint;
 
 import gnu.trove.set.TIntSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -23,9 +23,9 @@ public class MaskTest {
         /*
          * import Control.Monad
          * import Data.List
-         *         
+         *
          * powerset = filterM (const [True, False])
-         *         
+         *
          * solutions = do
          *     set <- powerset [1..6]
          *     masked <- powerset [0..3]

--- a/src/test/java/org/clafer/choco/constraint/MemberNonemptyTest.java
+++ b/src/test/java/org/clafer/choco/constraint/MemberNonemptyTest.java
@@ -7,11 +7,11 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Input;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.CSetVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/NotMemberTest.java
+++ b/src/test/java/org/clafer/choco/constraint/NotMemberTest.java
@@ -5,11 +5,11 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/OneTest.java
+++ b/src/test/java/org/clafer/choco/constraint/OneTest.java
@@ -6,10 +6,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/OrTest.java
+++ b/src/test/java/org/clafer/choco/constraint/OrTest.java
@@ -6,10 +6,10 @@ import org.clafer.test.NonEmpty;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/PrefixTest.java
+++ b/src/test/java/org/clafer/choco/constraint/PrefixTest.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.variables.CStringVar;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ReflexiveTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ReflexiveTest.java
@@ -10,10 +10,10 @@ import org.clafer.test.Positive;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.SetVar;
-import static solver.variables.VariableFactory.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.VariableFactory.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ReifyEqualXCTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ReifyEqualXCTest.java
@@ -4,11 +4,11 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/ReifyEqualXYTest.java
+++ b/src/test/java/org/clafer/choco/constraint/ReifyEqualXYTest.java
@@ -4,11 +4,11 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SelectNTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SelectNTest.java
@@ -4,11 +4,11 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetDifferenceTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetDifferenceTest.java
@@ -3,13 +3,13 @@ package org.clafer.choco.constraint;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetEqualTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetEqualTest.java
@@ -1,13 +1,13 @@
 package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetLowBoundTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetLowBoundTest.java
@@ -6,11 +6,11 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Input;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetMaxTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetMaxTest.java
@@ -5,15 +5,15 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Input;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.CSetVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.card;
-import static solver.variables.Var.cset;
-import static solver.variables.Var.env;
-import static solver.variables.Var.ker;
-import static solver.variables.VariableFactory.enumerated;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.card;
+import static org.chocosolver.solver.variables.Var.cset;
+import static org.chocosolver.solver.variables.Var.env;
+import static org.chocosolver.solver.variables.Var.ker;
+import static org.chocosolver.solver.variables.VariableFactory.enumerated;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetMinTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetMinTest.java
@@ -6,15 +6,15 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Input;
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.CSetVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.card;
-import static solver.variables.Var.cset;
-import static solver.variables.Var.env;
-import static solver.variables.Var.ker;
-import static solver.variables.VariableFactory.enumerated;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.card;
+import static org.chocosolver.solver.variables.Var.cset;
+import static org.chocosolver.solver.variables.Var.env;
+import static org.chocosolver.solver.variables.Var.ker;
+import static org.chocosolver.solver.variables.VariableFactory.enumerated;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetStrictHighBoundTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetStrictHighBoundTest.java
@@ -6,11 +6,11 @@ import org.clafer.choco.constraint.ConstraintQuickTest.Input;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SetSumTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetSumTest.java
@@ -2,14 +2,14 @@ package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import org.clafer.common.Util;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -22,9 +22,9 @@ public class SetSumTest {
     public Object testSumSet(Solver solver) {
         /*
          * import Control.Monad
-         *        
+         *
          * powerset = filterM (const [True, False])
-         *        
+         *
          * solutions = do
          *     set <- powerset [-4..3]
          *     guard $ length set <= 2
@@ -40,16 +40,16 @@ public class SetSumTest {
     public Object testSumNonPositiveSet(Solver solver) {
         /*
          * import Control.Monad
-         *        
+         *
          * powerset = filterM (const [True, False])
-         *        
+         *
          * solutions = do
          *     set <- powerset [-5..0]
          *     guard $ length set <= 4
          *     setSum <- [-4..2]
          *     guard $ sum set == setSum
          *     return set
-         *    
+         *
          */
         return $(cset("set", env(-5, -4, -3, -2, -1, 0), ker(), card(0, 1, 2, 3, 4), solver),
                 enumerated("sum", -4, 2, solver));

--- a/src/test/java/org/clafer/choco/constraint/SetUnionTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SetUnionTest.java
@@ -3,13 +3,13 @@ package org.clafer.choco.constraint;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SingletonTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SingletonTest.java
@@ -4,11 +4,11 @@ import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SortedSetTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SortedSetTest.java
@@ -2,13 +2,13 @@ package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
 import org.clafer.test.NonEmpty;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *
@@ -21,14 +21,14 @@ public class SortedSetTest {
     public Object testSortedSet(Solver solver) {
         /*
          * import Control.Monad
-         *         
+         *
          * positive = do
          *     a <- [0..3]
          *     b <- [0..3]
          *     c <- [0..3]
          *     guard $ a + b + c <= 3
          *     return (a, b, c)
-         *   
+         *
          *negative = 2^3 * 2^3 * 2^3 - length positive
          */
         CSetVar[] sets = new CSetVar[3];

--- a/src/test/java/org/clafer/choco/constraint/SuffixTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SuffixTest.java
@@ -1,14 +1,14 @@
 package org.clafer.choco.constraint;
 
 import static org.clafer.choco.constraint.ConstraintQuickTest.*;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.variables.CStringVar;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/SymmetryBreakingTest.java
+++ b/src/test/java/org/clafer/choco/constraint/SymmetryBreakingTest.java
@@ -1,16 +1,16 @@
 package org.clafer.choco.constraint;
 
 import org.clafer.test.TestUtil;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CSetVar;
 import static org.junit.Assert.*;
 import org.junit.Test;
-import solver.Solver;
-import solver.constraints.ICF;
-import solver.constraints.LCF;
-import solver.constraints.set.SCF;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.LCF;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/TransitiveClosureTest.java
+++ b/src/test/java/org/clafer/choco/constraint/TransitiveClosureTest.java
@@ -12,10 +12,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.SetVar;
-import static solver.variables.VariableFactory.set;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.VariableFactory.set;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/TransitiveReflexiveClosureTest.java
+++ b/src/test/java/org/clafer/choco/constraint/TransitiveReflexiveClosureTest.java
@@ -12,10 +12,10 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.SetVar;
-import static solver.variables.VariableFactory.set;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.VariableFactory.set;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/TransitiveTest.java
+++ b/src/test/java/org/clafer/choco/constraint/TransitiveTest.java
@@ -10,10 +10,10 @@ import org.clafer.test.Positive;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.SetVar;
-import static solver.variables.VariableFactory.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.SetVar;
+import static org.chocosolver.solver.variables.VariableFactory.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/UnreachableTest.java
+++ b/src/test/java/org/clafer/choco/constraint/UnreachableTest.java
@@ -7,10 +7,10 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/choco/constraint/propagator/PropUtilTest.java
+++ b/src/test/java/org/clafer/choco/constraint/propagator/PropUtilTest.java
@@ -6,19 +6,19 @@ import java.util.Arrays;
 import java.util.Random;
 import static org.junit.Assert.*;
 import org.junit.Test;
-import solver.Cause;
-import solver.ICause;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.Propagator;
-import solver.exception.ContradictionException;
-import solver.propagation.IPropagationEngine;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Var;
-import solver.variables.Variable;
-import solver.variables.events.IEventType;
-import solver.variables.events.PropagatorEventType;
+import org.chocosolver.solver.Cause;
+import org.chocosolver.solver.ICause;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.exception.ContradictionException;
+import org.chocosolver.solver.propagation.IPropagationEngine;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Var;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.events.IEventType;
+import org.chocosolver.solver.variables.events.PropagatorEventType;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrAcyclicTest.java
+++ b/src/test/java/org/clafer/ir/IrAcyclicTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrAddTest.java
+++ b/src/test/java/org/clafer/ir/IrAddTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrAllDifferentTest.java
+++ b/src/test/java/org/clafer/ir/IrAllDifferentTest.java
@@ -5,9 +5,9 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrAndTest.java
+++ b/src/test/java/org/clafer/ir/IrAndTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrArithmXYCTest.java
+++ b/src/test/java/org/clafer/ir/IrArithmXYCTest.java
@@ -9,14 +9,14 @@ import static org.junit.Assert.*;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
-import solver.variables.Variable;
-import solver.variables.impl.FixedBoolVarImpl;
-import solver.variables.impl.FixedIntVarImpl;
-import solver.variables.view.IntView;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.impl.FixedBoolVarImpl;
+import org.chocosolver.solver.variables.impl.FixedIntVarImpl;
+import org.chocosolver.solver.variables.view.IntView;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrArithmXYTest.java
+++ b/src/test/java/org/clafer/ir/IrArithmXYTest.java
@@ -7,14 +7,14 @@ import org.clafer.test.Term;
 import static org.junit.Assert.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
-import solver.variables.Variable;
-import solver.variables.impl.FixedBoolVarImpl;
-import solver.variables.impl.FixedIntVarImpl;
-import solver.variables.view.IntView;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.solver.variables.impl.FixedBoolVarImpl;
+import org.chocosolver.solver.variables.impl.FixedIntVarImpl;
+import org.chocosolver.solver.variables.view.IntView;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrArrayToSetTest.java
+++ b/src/test/java/org/clafer/ir/IrArrayToSetTest.java
@@ -6,9 +6,9 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CSetVar;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrBoolChannelTest.java
+++ b/src/test/java/org/clafer/ir/IrBoolChannelTest.java
@@ -4,10 +4,10 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.set.SCF;
-import solver.variables.BoolVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrCardTest.java
+++ b/src/test/java/org/clafer/ir/IrCardTest.java
@@ -4,10 +4,10 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.set.SCF;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrCompareTest.java
+++ b/src/test/java/org/clafer/ir/IrCompareTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrConcatTest.java
+++ b/src/test/java/org/clafer/ir/IrConcatTest.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CStringVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrCountTest.java
+++ b/src/test/java/org/clafer/ir/IrCountTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrDivTest.java
+++ b/src/test/java/org/clafer/ir/IrDivTest.java
@@ -5,9 +5,9 @@ import static org.clafer.ir.Irs.*;
 import static org.junit.Assume.assumeFalse;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrElementTest.java
+++ b/src/test/java/org/clafer/ir/IrElementTest.java
@@ -6,9 +6,9 @@ import org.clafer.test.Positive;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrIfOnlyIfTest.java
+++ b/src/test/java/org/clafer/ir/IrIfOnlyIfTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrIfThenElseTest.java
+++ b/src/test/java/org/clafer/ir/IrIfThenElseTest.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrImpliesTest.java
+++ b/src/test/java/org/clafer/ir/IrImpliesTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrIntChannelTest.java
+++ b/src/test/java/org/clafer/ir/IrIntChannelTest.java
@@ -6,9 +6,9 @@ import static org.clafer.ir.Irs.*;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrLengthTest.java
+++ b/src/test/java/org/clafer/ir/IrLengthTest.java
@@ -4,10 +4,10 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.CStringVar;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.CStringVar;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrLoneTest.java
+++ b/src/test/java/org/clafer/ir/IrLoneTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrMemberTest.java
+++ b/src/test/java/org/clafer/ir/IrMemberTest.java
@@ -5,9 +5,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrMulTest.java
+++ b/src/test/java/org/clafer/ir/IrMulTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrNotImpliesTest.java
+++ b/src/test/java/org/clafer/ir/IrNotImpliesTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrNotMemberTest.java
+++ b/src/test/java/org/clafer/ir/IrNotMemberTest.java
@@ -5,9 +5,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *
@@ -15,12 +15,12 @@ import solver.variables.SetVar;
  */
 @RunWith(IrQuickTest.class)
 public class IrNotMemberTest {
-    
+
     @Test(timeout = 60000)
     public IrBoolExpr setup(IrIntVar element, IrSetVar set) {
         return notMember(element, set);
     }
-    
+
     @Solution
     public Constraint setup(IntVar element, SetVar set) {
         return Constraints.notMember(element, set);

--- a/src/test/java/org/clafer/ir/IrNotTest.java
+++ b/src/test/java/org/clafer/ir/IrNotTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrOneTest.java
+++ b/src/test/java/org/clafer/ir/IrOneTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrOrTest.java
+++ b/src/test/java/org/clafer/ir/IrOrTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrPrefixTest.java
+++ b/src/test/java/org/clafer/ir/IrPrefixTest.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CStringVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrQuickTest.java
+++ b/src/test/java/org/clafer/ir/IrQuickTest.java
@@ -23,8 +23,8 @@ import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
-import solver.Solver;
-import solver.constraints.Constraint;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSelectNTest.java
+++ b/src/test/java/org/clafer/ir/IrSelectNTest.java
@@ -5,9 +5,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSetElementTest.java
+++ b/src/test/java/org/clafer/ir/IrSetElementTest.java
@@ -6,10 +6,10 @@ import org.clafer.test.Positive;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.set.SCF;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSetEqualityTest.java
+++ b/src/test/java/org/clafer/ir/IrSetEqualityTest.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CSetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CSetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSortStringTest.java
+++ b/src/test/java/org/clafer/ir/IrSortStringTest.java
@@ -6,9 +6,9 @@ import org.clafer.test.NonEmpty;
 import org.clafer.test.SameLength;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSortTest.java
+++ b/src/test/java/org/clafer/ir/IrSortTest.java
@@ -5,10 +5,10 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.constraints.LCF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.constraints.LCF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrStringCompareTest.java
+++ b/src/test/java/org/clafer/ir/IrStringCompareTest.java
@@ -6,8 +6,8 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CStringVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrStringElementTest.java
+++ b/src/test/java/org/clafer/ir/IrStringElementTest.java
@@ -7,10 +7,10 @@ import org.clafer.test.Positive;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CStringVar;
-import solver.variables.IntVar;
-import static solver.variables.Var.*;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CStringVar;
+import org.chocosolver.solver.variables.IntVar;
+import static org.chocosolver.solver.variables.Var.*;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSubsetEqTest.java
+++ b/src/test/java/org/clafer/ir/IrSubsetEqTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.set.SCF;
-import solver.variables.SetVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.set.SCF;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrSuffixTest.java
+++ b/src/test/java/org/clafer/ir/IrSuffixTest.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.CStringVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrUnreachableTest.java
+++ b/src/test/java/org/clafer/ir/IrUnreachableTest.java
@@ -8,8 +8,8 @@ import org.clafer.test.Positive;
 import static org.junit.Assume.assumeTrue;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *
@@ -17,14 +17,14 @@ import solver.variables.IntVar;
  */
 @RunWith(IrQuickTest.class)
 public class IrUnreachableTest {
-    
+
     @Test(timeout = 60000)
     public IrBoolExpr setup(@NonEmpty IrIntVar[] edges, @Positive int from, @Positive int to) {
         assumeTrue(from < edges.length);
         assumeTrue(to < edges.length);
         return unreachable(edges, from, to);
     }
-    
+
     @Solution
     public Constraint setup(IntVar[] edges, int from, int to) {
         return Constraints.unreachable(edges, from, to);

--- a/src/test/java/org/clafer/ir/IrWithinTest.java
+++ b/src/test/java/org/clafer/ir/IrWithinTest.java
@@ -6,9 +6,9 @@ import static org.clafer.ir.Irs.*;
 import org.clafer.test.NonEmpty;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.IntVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/IrXorTest.java
+++ b/src/test/java/org/clafer/ir/IrXorTest.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrQuickTest.Solution;
 import static org.clafer.ir.Irs.*;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import solver.constraints.Constraint;
-import solver.constraints.ICF;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.ICF;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/ir/compiler/IrCompilerTest.java
+++ b/src/test/java/org/clafer/ir/compiler/IrCompilerTest.java
@@ -7,9 +7,9 @@ import org.clafer.ir.IrSetVar;
 import static org.clafer.ir.Irs.*;
 import static org.junit.Assert.*;
 import org.junit.Test;
-import solver.Solver;
-import solver.search.strategy.SetStrategyFactory;
-import solver.variables.SetVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.search.strategy.SetStrategyFactory;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/test/BoolTerm.java
+++ b/src/test/java/org/clafer/test/BoolTerm.java
@@ -5,8 +5,8 @@ import org.clafer.ir.IrBoolVar;
 import org.clafer.ir.IrIntVar;
 import org.clafer.ir.compiler.IrSolutionMap;
 import static org.clafer.test.TestUtil.toVar;
-import solver.Solver;
-import solver.variables.BoolVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.BoolVar;
 
 /**
  *

--- a/src/test/java/org/clafer/test/FixedTerm.java
+++ b/src/test/java/org/clafer/test/FixedTerm.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import static org.clafer.ir.Irs.constant;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.IntVar;
-import solver.variables.Var;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Var;
 
 /**
  *

--- a/src/test/java/org/clafer/test/IntTerm.java
+++ b/src/test/java/org/clafer/test/IntTerm.java
@@ -4,8 +4,8 @@ import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import org.clafer.ir.compiler.IrSolutionMap;
 import static org.clafer.test.TestUtil.toVar;
-import solver.Solver;
-import solver.variables.IntVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/test/MinusTerm.java
+++ b/src/test/java/org/clafer/test/MinusTerm.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import static org.clafer.ir.Irs.minus;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.IntVar;
-import solver.variables.Var;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Var;
 
 /**
  *

--- a/src/test/java/org/clafer/test/NotTerm.java
+++ b/src/test/java/org/clafer/test/NotTerm.java
@@ -5,10 +5,10 @@ import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import static org.clafer.ir.Irs.not;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.Var;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Var;
 
 /**
  *

--- a/src/test/java/org/clafer/test/OffsetTerm.java
+++ b/src/test/java/org/clafer/test/OffsetTerm.java
@@ -4,9 +4,9 @@ import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import static org.clafer.ir.Irs.add;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.IntVar;
-import solver.variables.Var;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.Var;
 
 /**
  *

--- a/src/test/java/org/clafer/test/Term.java
+++ b/src/test/java/org/clafer/test/Term.java
@@ -3,8 +3,8 @@ package org.clafer.test;
 import org.clafer.ir.IrIntExpr;
 import org.clafer.ir.IrIntVar;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.IntVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.IntVar;
 
 /**
  *

--- a/src/test/java/org/clafer/test/TestReflection.java
+++ b/src/test/java/org/clafer/test/TestReflection.java
@@ -1,7 +1,7 @@
 package org.clafer.test;
 
-import solver.variables.CSetVar;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CStringVar;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.set.hash.TIntHashSet;
 import java.lang.annotation.Annotation;
@@ -17,10 +17,10 @@ import org.clafer.ir.IrSetVar;
 import org.clafer.ir.IrStringVar;
 import org.clafer.ir.IrVar;
 import org.clafer.ir.compiler.IrSolutionMap;
-import solver.Solver;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
 
 /**
  *

--- a/src/test/java/org/clafer/test/TestUtil.java
+++ b/src/test/java/org/clafer/test/TestUtil.java
@@ -1,7 +1,7 @@
 package org.clafer.test;
 
-import solver.variables.CSetVar;
-import solver.variables.CStringVar;
+import org.chocosolver.solver.variables.CSetVar;
+import org.chocosolver.solver.variables.CStringVar;
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import java.util.ArrayList;
@@ -16,20 +16,20 @@ import org.clafer.ir.IrIntVar;
 import org.clafer.ir.IrSetVar;
 import org.clafer.ir.IrStringVar;
 import static org.clafer.ir.Irs.*;
-import solver.Solver;
-import solver.constraints.Constraint;
-import solver.constraints.Propagator;
-import solver.search.strategy.ISF;
-import solver.search.strategy.SetStrategyFactory;
-import solver.search.strategy.selectors.SetValueSelector;
-import solver.search.strategy.strategy.AbstractStrategy;
-import solver.search.strategy.strategy.SetStrategy;
-import solver.variables.BoolVar;
-import solver.variables.IntVar;
-import solver.variables.SetVar;
-import solver.variables.Var;
-import solver.variables.Variable;
-import util.ESat;
+import org.chocosolver.solver.Solver;
+import org.chocosolver.solver.constraints.Constraint;
+import org.chocosolver.solver.constraints.Propagator;
+import org.chocosolver.solver.search.strategy.ISF;
+import org.chocosolver.solver.search.strategy.SetStrategyFactory;
+import org.chocosolver.solver.search.strategy.selectors.SetValueSelector;
+import org.chocosolver.solver.search.strategy.strategy.AbstractStrategy;
+import org.chocosolver.solver.search.strategy.strategy.SetStrategy;
+import org.chocosolver.solver.variables.BoolVar;
+import org.chocosolver.solver.variables.IntVar;
+import org.chocosolver.solver.variables.SetVar;
+import org.chocosolver.solver.variables.Var;
+import org.chocosolver.solver.variables.Variable;
+import org.chocosolver.util.ESat;
 
 /**
  *
@@ -87,7 +87,7 @@ public class TestUtil {
 
     private static SetStrategy randomSearch(SetVar[] vars) {
         return SetStrategyFactory.custom(
-                new solver.search.strategy.selectors.variables.Random<SetVar>(rand.nextLong()),
+                new org.chocosolver.solver.search.strategy.selectors.variables.Random<SetVar>(rand.nextLong()),
                 new RandomSetValueSelector(), randBool(), vars);
     }
 


### PR DESCRIPTION
renamed imports, moved our 'solver.variables' to
'org.chocosolver.solver.variables'
two test cases fail.
Configuration class is gone, using Settings