### PR TITLE
Release 0.4.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
-# chocosolver version 0.4.3 released on Dec ??, 2015
+# chocosolver version 0.4.3 released on Dec 22, 2015
 
-[Release](https://github.com/gsdlab/chocosolver/pull/23)
+[Release](https://github.com/gsdlab/chocosolver/pull/26)
 
 # chocosolver version 0.4.2.1 released on Nov 03, 2015
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # chocosolver
 
-v0.4.3
+##### v0.4.3
 
 An instance generator and multi-objective optimizer backend for [Clafer](http://clafer.org) using the Choco 3.3 constraint programming library. There are two ways to use the project:
 programmatically via the Java API or via the command-line interface (CLI).
@@ -35,7 +35,7 @@ See [ClaferToolsST](https://github.com/gsdlab/ClaferToolsST).
 
 ## Prerequisites
 
-* [Choco 3.3+](https://github.com/chocoteam/choco3), v3.3.3-SNAPSHOT (the branch `develop`).
+* [Choco 3.3+](https://github.com/chocoteam/choco3), v3.3.3.
 * [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html), 64bit.
 * [Maven 3.2+](http://maven.apache.org/). Required for building the project.
 
@@ -48,14 +48,6 @@ See [ClaferToolsST](https://github.com/gsdlab/ClaferToolsST).
 Follow the installation instructions in the [README.md](https://github.com/gsdlab/clafer#clafer).
 
 ## Installation
-
-Install Choco3 development snapshot:
-
-```bash
-git clone https://github.com/chocoteam/choco3.git -b develop
-cd choco3
-mvn install -DskipTests
-```
 
 Install the API and the CLI.
 
@@ -84,7 +76,7 @@ You can deploy the files the same way as in Clafer Tools binary distribution by 
 make install to=<target path>
 ```
 
-### Important: Branches must correspond
+### Important: branches must correspond
 
 All related projects are following the *simultaneous release model*.
 The branch `master` contains releases, whereas the branch `develop` contains code under development.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The CLI is used by
 ## Contributors
 
 * [Jimmy Liang](http://gsd.uwaterloo.ca/jliang), MSc. Candidate. Main developer.
-* [Michal Antkiewicz](http://gsd.uwaterloo.ca/mantkiew), Research Engineer. Release Management, testing.
+* [Michal Antkiewicz](http://gsd.uwaterloo.ca/mantkiew), Research Engineer. Release Management, development, testing.
 * [Alexandr Murashkin](http://gsd.uwaterloo.ca/amurashk). CLI, stress testing.
 * [Jordan Ross](http://gsd.uwaterloo.ca/j25ross). Stress testing.
 
@@ -35,13 +35,13 @@ See [ClaferToolsST](https://github.com/gsdlab/ClaferToolsST).
 
 ## Prerequisites
 
-* [Choco 3.3+](https://github.com/chocoteam/choco3), v3.3.2-SNAPSHOT.
+* [Choco 3.3+](https://github.com/chocoteam/choco3), v3.3.3-SNAPSHOT (the branch `develop`).
 * [Java 8+](http://www.oracle.com/technetwork/java/javase/downloads/index.html), 64bit.
 * [Maven 3.2+](http://maven.apache.org/). Required for building the project.
 
 ## Recommended but optional
 
-* [Clafer compiler](https://github.com/gsdlab/clafer), v0.4.3.
+* [Clafer compiler](https://github.com/gsdlab/clafer), v0.4.3 (also works with 0.4.2).
   - This backend provides an API for solving Clafer models. The Clafer compiler can compile a Clafer model down to the proper API calls.
   - The API calls can also be written manually quite easily with a bit of extra typing (examples down below).
 
@@ -78,12 +78,18 @@ Include the following XML snippet in your POM to use the API in your Maven proje
 The CLI is installed to `target/chocosolver-0.4.3-jar-with-dependencies.jar`;
 however, in the Clafer Tools binary distribution it is called `chocosolver.jar`.
 
+You can deploy the files the same way as in Clafer Tools binary distribution by executing
+
+```bash
+make install to=<target path>
+```
+
 ### Important: Branches must correspond
 
 All related projects are following the *simultaneous release model*.
 The branch `master` contains releases, whereas the branch `develop` contains code under development.
 When building the tools, the branches should match.
-Releases from branches 'master` are guaranteed to work well together.
+Releases from branches `master` are guaranteed to work well together.
 Development versions from branches `develop` should work well together but this might not always be the case.
 
 
@@ -117,7 +123,7 @@ The CLI supports four modes of operation:
 * `-v` - validation mode,
 * `--repl` - interactive mode,
 * `-moo` - batch multi-objective optimization mode, and
-* batch instance generation mode.
+* (default) batch instance generation mode.
 
 The last mode is selected when no `-v` and `--repl` are given and the model does not contain optimization objectives.
 
@@ -125,6 +131,14 @@ If the `.cfr` file is given, the CLI will first call the Clafer compiler using `
 which will produce `model.js`.
 Certain features, such as transitive closure, are not yet supported by Clafer,
 so they can only be used directly via API call in the `.js` file.
+We recommend using the so called Choco escapes, as follows:
+
+
+```
+[choco|
+<your code to be inserted verbatim at the end of the generated output>
+|]
+```
 
 ### CLI interactive mode
 
@@ -136,9 +150,12 @@ Type 'help' for the list of available REPL commands
 
 === Instance 1 Begin ===
 
-c0_aCar$0 : c0_Car
-  c0_Transmission$0
-    c0_Manual$0
+Bob
+  owns -> car
+car
+  transmission
+    manual
+  drivenBy -> Bob
 
 --- Instance 1 End ---
 
@@ -184,7 +201,7 @@ In general, the CLI classes are good examples of using the API:
 
 Consider the following Clafer model.
 
-```clafer
+```
 Installation
     xor Status
         Ok
@@ -192,6 +209,7 @@ Installation
     Time -> integer
         [this > 2]
 ```
+
 Below is an example of using the API to build the model above. [AstModel](http://gsdlab.github.io/chocosolver/org/clafer/ast/AstModel.html) represents the implicit "root" of the model.
 Every Clafer in the model is nested below it.
 
@@ -215,12 +233,13 @@ public static void main(String[] args) {
             // Note that joinRef is explicit whereas it was implicit in the original model.
 }
 ```
+
 The [Asts](http://gsdlab.github.io/chocosolver/org/clafer/ast/Asts.html) class provides all the functions required for building the model. See the previous link for a list of all the supported expressions. More examples of building models: [structure](https://github.com/gsdlab/chocosolver/blob/master/src/test/java/org/clafer/SimpleStructureTest.java), [expressions](https://github.com/gsdlab/chocosolver/blob/master/src/test/java/org/clafer/SimpleConstraintTest.java), [quantifiers](https://github.com/gsdlab/chocosolver/blob/master/src/test/java/org/clafer/QuantifierTest.java), and [attributed feature models](https://github.com/gsdlab/chocosolver/blob/master/src/test/java/org/clafer/FeatureModelTest.java#L229).
 
 ### Finding Instances
 
-
 The next step is to solve the model.
+
 ```java
 import org.clafer.compiler.*;
 import org.clafer.scope.*;
@@ -245,6 +264,7 @@ public static void main(String[] args) {
 ### Finding Optimal Instances
 
 Optimizing on a single objective is supported. Suppose we wanted to optimize on the expression "sum time".
+
 ```java
 import org.clafer.objective.*;
 ...
@@ -281,6 +301,7 @@ Floats ?
 [Witch]
 ```
 The model is overconstrained and has no solutions. The solver can help here as well.
+
 ```java
 AstModel model = newModel();
 AstConcreteClafer mob = model.addChild("Mob").withCard(0, 1);
@@ -297,11 +318,18 @@ ClaferUnsat unsat = ClaferCompiler.compileUnsat(model, Scope.defaultScope(1));
 // Print the Min-Unsat and near-miss example.
 System.out.println(unsat.minUnsat());
 ```
-The above code will print two things. First it will print "#(Witch) >= 1" which is the constraint that is unsatisfiable in the model, ie. the last constraint that enforces there to be some witch. Next it will print the near-miss example "Mob#0". What this means is that removing the "some(Witch)" constraint would make the model satisfiable and an example of a solution (after removing the constraint), is the instance with exactly one mob and nothing else. For this example, the min-unsat is not unique, so it is possible that the library may report another set of constraints although the set of constraints is guaranteed to have a size of one.
+
+The above code will print two things.
+First it will print "#(Witch) >= 1" which is the constraint that is unsatisfiable in the model, i.e., the last constraint that enforces there to be some witch.
+Next, it will print the near-miss example `Mob#0`.
+It means that removing the `some(Witch)` constraint would make the model satisfiable and an example of a solution (after removing the constraint), is the instance with exactly one mob and nothing else.
+For this example, the min-unsat is not unique, so it is possible that the library may report another set of constraints although the set of constraints is guaranteed to have a size of one.
 
 ### Finding Unsat-Core
 
-The above example found that removing one constraint will *fix* the model but you may be wondering why the model cannot have a witch. In this case, it is more useful to compute the Unsat-Core instead.
+The above example found that removing one constraint will *fix* the model but you may be wondering why the model cannot have a witch.
+In this case, it is more useful to compute the unsat-core instead.
+
 ```java
 ClaferUnsat unsat = ClaferCompiler.compileUnsat(model, Scope.defaultScope(1));
 // Print the Unsat-Core.
@@ -326,7 +354,7 @@ public static void main(String[] args) {
 
 ## Configuring as a Web Tool Backend
 
-The configuration is done in the `<host-tool-path>/Server/Backends/backends.json` file, where `<host-tool-path>` is a path to the web-based tool (`ClaferIDE`, etc.) you want to configure to use `ClaferChocoIG` as a backend.
+The configuration is done in the `<host-tool-path>/Server/Backends/backends.json` file, where `<host-tool-path>` is a path to the web-based tool (`ClaferIDE`, etc.) you want to configure to use `chocosolver` as a backend.
 
 * An example configuration for [ClaferIDE](https://github.com/gsdlab/ClaferIDE):
 
@@ -339,8 +367,8 @@ The configuration is done in the `<host-tool-path>/Server/Backends/backends.json
             "tooltip": "An instance generator and multi-objective optimizer based on Choco3 solver library",
             "accepted_format": "choco",
             "tool": "java",
-            "tool_args": ["-jar", "~/bin/chocosolver.jar", "--file=$filepath$", "--repl", "--prettify"],
-            "tool_version_args": ["-jar", "~/bin/chocosolver.jar", "--version"],
+            "tool_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--file=$filepath$", "--repl", "--prettify"],
+            "tool_version_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--version"],
             "scope_options": {
                 "set_default_scope" : {"command": "SetGlobalScope $value$\n", "label": "Default:", "argument": "--scope=$value$", "default_value": 1},
                 "set_individual_scope": {"command": "setScope $clafer$ $value$\n"},
@@ -374,8 +402,8 @@ The configuration is done in the `<host-tool-path>/Server/Backends/backends.json
             "tooltip": "A multi-objective optimizer based on Choco3 solver library",
             "accepted_format": "choco",
             "tool": "java",
-            "tool_args": ["-jar", "~/bin/chocosolver.jar", "--file=$filepath$", "--moo"],
-            "tool_version_args": ["-jar", "~/bin/chocosolver.jar", "--version"],
+            "tool_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--file=$filepath$", "--moo"],
+            "tool_version_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--version"],
             "optimization_options": {
                 "set_int_scope" : {"label": "Max. integer:", "argument": "--maxint=$value$", "default_value": 127},
                 "set_default_scope" : {"label": "Default scopes:", "argument": "--scope=$value$", "default_value": 25}
@@ -396,8 +424,8 @@ The configuration is done in the `<host-tool-path>/Server/Backends/backends.json
             "tooltip": "An instance generator based on Choco3 solver library",
             "accepted_format": "choco",
             "tool": "java",
-            "tool_args": ["-jar", "~/bin/chocosolver.jar", "--file=$filepath$", "--repl"],
-            "tool_version_args": ["-jar", "~/bin/chocosolver.jar", "--version"],
+            "tool_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--file=$filepath$", "--repl"],
+            "tool_version_args": ["-jar", "/home/<user>/bin/chocosolver.jar", "--version"],
             "scope_options": {
                 "set_default_scope" : {"command": "SetGlobalScope $value$\n"},
                 "set_individual_scope": {"command": "setScope $clafer$ $value$\n"},
@@ -429,15 +457,22 @@ Also, check the `eXecute` permission on the `jar` file.
 ## Semantic Differences with the Alloy backend
 
 Consider the following constraint.
-```clafer
+
+```
 [5 + 5 = -6]
 ```
-For this backend, the constraint is always unsatisfiable. For the Alloy backend, the constraint can be satisfied, depending on the set bitwidth. Why? In the default bitwidth of 4, the number succeeding 7 is -8. Hence 5 + 5 is translated to 5 -> 6 -> 7 -> -8 -> -7 -> -6, hence the constraint is true. For any other bitwidth, the constraint is false. Overflow can be a problem for low bitwidths when dealing with arithmetic. This backend can also suffer from overflow. It essentially, in regards to overflow, has a fixed bitwidth of 32.
+
+For this backend, the constraint is always unsatisfiable.
+For the Alloy backend, the constraint can be satisfied, depending on the set bitwidth.
+Why? In the default bitwidth of 4, the number succeeding 7 is -8. Hence 5 + 5 is translated to 5 -> 6 -> 7 -> -8 -> -7 -> -6, hence the constraint is true.
+For any other bitwidth, the constraint is false.
+Overflow can be a problem for low bitwidths when dealing with arithmetic (in the new Alloy there's an option which prevents overflows).
+This backend can also suffer from overflow.
+It essentially, in regards to overflow, has a fixed bitwidth of 32.
 
 ## Possible Future Work?
 
 * API for choosing branching strategy. Two reasons. The advantage of constraint programming is the ability to tune the solver to the specific problem. Choosing the right branching strategy can make a world of difference. Secondly, it allows the user to control the order of instances generated. For example, the user would like to see instances where Feature A is present and Feature B is absent before any other instances. This can be done by choosing the branching strategy.
-* Transitive closure, inverse
 * Reals
 
 # Need help?

--- a/pom.xml
+++ b/pom.xml
@@ -27,18 +27,13 @@
         <dependency>
             <groupId>org.choco-solver</groupId>
             <artifactId>choco-solver</artifactId>
-            <version>3.3.3-SNAPSHOT</version>
+            <version>3.3.3</version>
         </dependency>
         <dependency>
     	    <groupId>net.sf.jopt-simple</groupId>
     	    <artifactId>jopt-simple</artifactId>
-    	    <version>4.6</version>
+    	    <version>4.9</version>
     	  </dependency>
-<!--        <dependency>
-            <groupId>org.choco-solver</groupId>
-            <artifactId>choco-graph</artifactId>
-            <version>3.3.1-SNAPSHOT</version>
-        </dependency>-->
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.choco-solver</groupId>
             <artifactId>choco-solver</artifactId>
-            <version>3.3.2-SNAPSHOT</version>
+            <version>3.3.3-SNAPSHOT</version>
         </dependency>
         <dependency>
     	    <groupId>net.sf.jopt-simple</groupId>

--- a/src/main/java/org/clafer/ast/AstAbstractClafer.java
+++ b/src/main/java/org/clafer/ast/AstAbstractClafer.java
@@ -3,6 +3,7 @@ package org.clafer.ast;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.clafer.common.Check;
 
 /**
  * An abstract Clafer.
@@ -11,10 +12,18 @@ import java.util.List;
  */
 public class AstAbstractClafer extends AstClafer {
 
+    private final AstAbstractClafer parent;
+    private final List<AstAbstractClafer> abstractChildren = new ArrayList<>();
     private final List<AstClafer> subs = new ArrayList<>();
 
     AstAbstractClafer(String name, AstAbstractClafer claferClafer) {
         super(name, claferClafer);
+        this.parent = null;
+    }
+
+    AstAbstractClafer(String name, AstAbstractClafer parent, AstAbstractClafer claferClafer) {
+        super(name, claferClafer);
+        this.parent = Check.notNull(parent);
     }
 
     @Override
@@ -31,6 +40,23 @@ public class AstAbstractClafer extends AstClafer {
     @Override
     public AstAbstractClafer withGroupCard(int low, int high) {
         return withGroupCard(new Card(low, high));
+    }
+
+    public boolean hasAbstractChildren() {
+        return !abstractChildren.isEmpty();
+    }
+
+    public List<AstAbstractClafer> getAbstractChildren() {
+        return Collections.unmodifiableList(abstractChildren);
+    }
+
+    public AstAbstractClafer addAbstractChild(String name) {
+        AstAbstractClafer child = new AstAbstractClafer(name, this, getClaferClafer());
+        if (getClaferClafer() != null) {
+            child.extending(getClaferClafer());
+        }
+        abstractChildren.add(child);
+        return child;
     }
 
     /**
@@ -66,6 +92,16 @@ public class AstAbstractClafer extends AstClafer {
     public AstAbstractClafer refToUnique(AstClafer targetType) {
         super.refToUnique(targetType);
         return this;
+    }
+
+    @Override
+    public boolean hasParent() {
+        return parent != null;
+    }
+
+    @Override
+    public AstAbstractClafer getParent() {
+        return parent;
     }
 
     @Override

--- a/src/main/java/org/clafer/ast/AstChildRelation.java
+++ b/src/main/java/org/clafer/ast/AstChildRelation.java
@@ -8,13 +8,13 @@ import org.clafer.common.Check;
  */
 public class AstChildRelation implements AstSetExpr {
 
-    private final AstConcreteClafer childRelation;
+    private final AstClafer childRelation;
 
-    AstChildRelation(AstConcreteClafer childRelation) {
+    AstChildRelation(AstClafer childRelation) {
         this.childRelation = Check.notNull(childRelation);
     }
 
-    public AstConcreteClafer getChildType() {
+    public AstClafer getChildType() {
         return childRelation;
     }
 

--- a/src/main/java/org/clafer/ast/AstClafer.java
+++ b/src/main/java/org/clafer/ast/AstClafer.java
@@ -188,6 +188,10 @@ public abstract class AstClafer implements AstVar {
         return withGroupCard(new Card(low, high));
     }
 
+    public abstract boolean hasParent();
+
+    public abstract AstClafer getParent();
+
     /**
      * Checks if this Clafer has any concrete children.
      *
@@ -207,6 +211,10 @@ public abstract class AstClafer implements AstVar {
         return Collections.unmodifiableList(children);
     }
 
+    protected AstAbstractClafer getClaferClafer() {
+        return claferClafer;
+    }
+
     /**
      * Add a new concrete child under this Clafer.
      *
@@ -214,9 +222,9 @@ public abstract class AstClafer implements AstVar {
      * @return the new child
      */
     public AstConcreteClafer addChild(String name) {
-        AstConcreteClafer child = new AstConcreteClafer(name, this, claferClafer);
+        AstConcreteClafer child = new AstConcreteClafer(name, this, getClaferClafer());
         children.add(child);
-        return child.extending(claferClafer);
+        return child.extending(getClaferClafer());
     }
 
     /**

--- a/src/main/java/org/clafer/ast/AstConcreteClafer.java
+++ b/src/main/java/org/clafer/ast/AstConcreteClafer.java
@@ -29,6 +29,7 @@ public class AstConcreteClafer extends AstClafer {
      * @return {@code true} if and only if this Clafer has a parent,
      * {@code false} otherwise
      */
+    @Override
     public boolean hasParent() {
         return parent != null;
     }
@@ -38,6 +39,7 @@ public class AstConcreteClafer extends AstClafer {
      *
      * @return this Clafer's parent
      */
+    @Override
     public AstClafer getParent() {
         return parent;
     }

--- a/src/main/java/org/clafer/ast/AstModel.java
+++ b/src/main/java/org/clafer/ast/AstModel.java
@@ -52,6 +52,10 @@ public class AstModel {
         return rootClafer;
     }
 
+    public AstAbstractClafer getTypeRoot() {
+        return typeRoot;
+    }
+
     /**
      * Returns all the abstract Clafers
      *

--- a/src/main/java/org/clafer/ast/AstModel.java
+++ b/src/main/java/org/clafer/ast/AstModel.java
@@ -1,7 +1,5 @@
 package org.clafer.ast;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -27,25 +25,31 @@ import java.util.List;
  *
  * @author jimmy
  */
-public class AstModel extends AstConcreteClafer {
+public class AstModel {
 
-    private final List<AstAbstractClafer> abstracts;
+    private final AstAbstractClafer abstractRootClafer;
+    private final AstConcreteClafer rootClafer;
+    // the type every non-primitive non-root type extends from.
+    private final AstAbstractClafer typeRoot;
 
     AstModel() {
-        super("#root#", new AstAbstractClafer("#clafer#", null));
-        super.withCard(new Card(1, 1));
-        this.abstracts = new ArrayList<>();
-        this.abstracts.add(claferClafer);
-        super.extending(claferClafer);
+        this.abstractRootClafer = new AstAbstractClafer("#root#", null) {
+
+            @Override
+            protected AstAbstractClafer getClaferClafer() {
+                return typeRoot;
+            }
+        };
+        this.rootClafer = new AstConcreteClafer("root", null).extending(abstractRootClafer).withCard(1, 1);
+        this.typeRoot = abstractRootClafer.addAbstractChild("#clafer#");
     }
 
-    /**
-     * Returns the type every non-primitive type extends from.
-     *
-     * @return the Clafer named "clafer"
-     */
-    public AstAbstractClafer getTypeHierarchyRoot() {
-        return claferClafer;
+    public AstAbstractClafer getAbstractRoot() {
+        return abstractRootClafer;
+    }
+
+    public AstConcreteClafer getRoot() {
+        return rootClafer;
     }
 
     /**
@@ -54,7 +58,7 @@ public class AstModel extends AstConcreteClafer {
      * @return all the abstract Clafers
      */
     public List<AstAbstractClafer> getAbstracts() {
-        return Collections.unmodifiableList(abstracts);
+        return abstractRootClafer.getAbstractChildren();
     }
 
     /**
@@ -64,33 +68,26 @@ public class AstModel extends AstConcreteClafer {
      * @return the new abstract Clafer
      */
     public AstAbstractClafer addAbstract(String name) {
-        AstAbstractClafer abstractClafer = new AstAbstractClafer(name, claferClafer).extending(claferClafer);
-        abstracts.add(abstractClafer);
-        return abstractClafer;
+        return abstractRootClafer.addAbstractChild(name);
     }
 
-    @Override
-    public AstModel extending(AstAbstractClafer superClafer) {
-        throw new UnsupportedOperationException("Cannot extend from " + getName());
+    public List<AstConcreteClafer> getChildren() {
+        return abstractRootClafer.getChildren();
     }
 
-    @Override
-    public AstModel refTo(AstClafer targetType) {
-        throw new UnsupportedOperationException("Cannot ref from " + getName());
+    public AstConcreteClafer addChild(String name) {
+        return abstractRootClafer.addChild(name);
     }
 
-    @Override
-    public AstModel refToUnique(AstClafer targetType) {
-        throw new UnsupportedOperationException("Cannot ref from " + getName());
+    public boolean hasConstraints() {
+        return abstractRootClafer.hasConstraints();
     }
 
-    @Override
-    public AstConcreteClafer withCard(Card card) {
-        throw new UnsupportedOperationException("Cannot set cardinality for " + getName());
+    public List<AstConstraint> getConstraints() {
+        return abstractRootClafer.getConstraints();
     }
 
-    @Override
-    public AstModel withGroupCard(Card groupCard) {
-        throw new UnsupportedOperationException("Cannot set group cardinality for " + getName());
+    public AstConstraint addConstraint(AstBoolExpr expr) {
+        return abstractRootClafer.addConstraint(expr);
     }
 }

--- a/src/main/java/org/clafer/ast/AstPrimClafer.java
+++ b/src/main/java/org/clafer/ast/AstPrimClafer.java
@@ -38,6 +38,16 @@ public abstract class AstPrimClafer extends AstClafer {
     }
 
     @Override
+    public boolean hasParent() {
+        return false;
+    }
+
+    @Override
+    public AstClafer getParent() {
+        return null;
+    }
+
+    @Override
     public AstConcreteClafer addChild(String name) {
         throw new UnsupportedOperationException("Cannot add a child under " + getName() + " primitive");
     }

--- a/src/main/java/org/clafer/ast/AstUtil.java
+++ b/src/main/java/org/clafer/ast/AstUtil.java
@@ -32,14 +32,8 @@ public class AstUtil {
      */
     public static List<AstClafer> getClafers(AstModel model) {
         List<AstClafer> clafers = new ArrayList<>();
-        clafers.add(model.getAbstractRoot());
-        clafers.add(model.getRoot());
-        for (AstAbstractClafer abstractClafer : model.getAbstracts()) {
-            getNestedClafers(abstractClafer, clafers);
-        }
-        for (AstConcreteClafer child : model.getChildren()) {
-            getNestedClafers(child, clafers);
-        }
+        getNestedClafers(model.getAbstractRoot(), clafers);
+        getNestedClafers(model.getRoot(), clafers);
         return clafers;
     }
 
@@ -64,13 +58,55 @@ public class AstUtil {
      * Find all the nested concrete Clafers in no specific order.
      *
      * @param model the Clafer model
-     * @return the concrete Clafers in the model excluding the root
+     * @return the concrete Clafers in the model
+     */
+    public static List<AstAbstractClafer> getAbstractClafers(AstModel model) {
+        List<AstAbstractClafer> clafers = new ArrayList<>();
+        getNestedAbstractClafers(model.getAbstractRoot(), clafers);
+        getNestedAbstractClafers(model.getRoot(), clafers);
+        return clafers;
+    }
+
+    private static void getNestedAbstractClafers(AstAbstractClafer abstractClafer, List<AstAbstractClafer> clafers) {
+        clafers.add(abstractClafer);
+        for (AstAbstractClafer child : abstractClafer.getAbstractChildren()) {
+            getNestedAbstractClafers(child, clafers);
+        }
+        for (AstConcreteClafer child : abstractClafer.getChildren()) {
+            getNestedAbstractClafers(child, clafers);
+        }
+    }
+
+    private static void getNestedAbstractClafers(AstConcreteClafer concreteClafer, List<AstAbstractClafer> clafers) {
+    }
+
+    /**
+     * Find all the nested concrete Clafers in no specific order.
+     *
+     * @param model the Clafer model
+     * @return the concrete Clafers in the model
      */
     public static List<AstConcreteClafer> getConcreteClafers(AstModel model) {
         List<AstConcreteClafer> clafers = new ArrayList<>();
-        getNestedChildClafers(model.getAbstractRoot(), clafers);
-        clafers.add(model.getRoot());
+        getNestedConcreteClafers(model.getAbstractRoot(), clafers);
+        getNestedConcreteClafers(model.getRoot(), clafers);
         return clafers;
+    }
+
+    private static void getNestedConcreteClafers(AstAbstractClafer abstractClafer, List<AstConcreteClafer> clafers) {
+        for (AstAbstractClafer child : abstractClafer.getAbstractChildren()) {
+            getNestedConcreteClafers(child, clafers);
+        }
+        for (AstConcreteClafer child : abstractClafer.getChildren()) {
+            getNestedConcreteClafers(child, clafers);
+        }
+    }
+
+    private static void getNestedConcreteClafers(AstConcreteClafer concreteClafer, List<AstConcreteClafer> clafers) {
+        clafers.add(concreteClafer);
+        for (AstConcreteClafer child : concreteClafer.getChildren()) {
+            getNestedConcreteClafers(child, clafers);
+        }
     }
 
     /**

--- a/src/main/java/org/clafer/ast/Asts.java
+++ b/src/main/java/org/clafer/ast/Asts.java
@@ -71,7 +71,7 @@ public class Asts {
         return new AstJoin(left, right);
     }
 
-    public static AstSetExpr join(AstSetExpr left, AstConcreteClafer right) {
+    public static AstSetExpr join(AstSetExpr left, AstClafer right) {
         return new AstJoin(left, relation(right));
     }
 
@@ -407,7 +407,7 @@ public class Asts {
         return new AstSuffix(suffix, word);
     }
 
-    public static AstSetExpr relation(AstConcreteClafer child) {
+    public static AstSetExpr relation(AstClafer child) {
         return new AstChildRelation(child);
     }
 

--- a/src/main/java/org/clafer/ast/analysis/CardAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/CardAnalyzer.java
@@ -17,18 +17,16 @@ public class CardAnalyzer implements Analyzer {
     @Override
     public Analysis analyze(Analysis analysis) {
         Map<AstConcreteClafer, Card> cardMap = new HashMap<>();
-        cardMap.put(analysis.getModel(), new Card(1, 1));
-        for (AstAbstractClafer abstractClafer : analysis.getAbstractClafers()) {
-            analyze(abstractClafer, cardMap, analysis);
-        }
-        for (AstConcreteClafer child : analysis.getModel().getChildren()) {
-            analyze(child, 1, cardMap, analysis);
-        }
+        analyze(analysis.getModel().getAbstractRoot(), cardMap, analysis);
+        analyze(analysis.getModel().getRoot(), 1, cardMap, analysis);
         return analysis.setCardMap(cardMap);
     }
 
     private static void analyze(AstAbstractClafer clafer, Map<AstConcreteClafer, Card> cardMap, Analysis analysis) {
         Card globalCard = analysis.getGlobalCard(clafer);
+        for (AstAbstractClafer child : clafer.getAbstractChildren()) {
+            analyze(child, cardMap, analysis);
+        }
         for (AstConcreteClafer child : clafer.getChildren()) {
             analyze(child, globalCard.getLow(), cardMap, analysis);
         }

--- a/src/main/java/org/clafer/ast/analysis/FormatAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/FormatAnalyzer.java
@@ -15,7 +15,7 @@ public class FormatAnalyzer implements Analyzer {
     @Override
     public Analysis analyze(Analysis analysis) {
         Map<AstClafer, Format> formatMap = new HashMap<>();
-        formatMap.put(analysis.getModel(), Format.LowGroup);
+        formatMap.put(analysis.getModel().getRoot(), Format.LowGroup);
         for (AstAbstractClafer abstractClafer : analysis.getAbstractClafers()) {
             analyze(abstractClafer, analysis, formatMap);
         }

--- a/src/main/java/org/clafer/ast/analysis/GlobalCardAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/GlobalCardAnalyzer.java
@@ -58,7 +58,6 @@ public class GlobalCardAnalyzer implements Analyzer {
     @Override
     public Analysis analyze(Analysis analysis) {
         Map<AstClafer, Card> globalCardMap = new HashMap<>();
-        globalCardMap.put(analysis.getModel(), new Card(1, 1));
         globalCardMap.put(IntType, new Card(0, analysis.getScope().getIntHigh() - analysis.getScope().getIntLow() + 1));
         List<Pair<AstClafer, Integer>> insufficientScopes = new ArrayList<>();
 
@@ -209,15 +208,20 @@ public class GlobalCardAnalyzer implements Analyzer {
 
     private static void analyze(AstAbstractClafer clafer, Analysis analysis,
             Map<AstClafer, Card> globalCardMap, List<Pair<AstClafer, Integer>> insufficientScopes) {
-        Card globalCard = new Card(0, 0);
-        for (AstClafer sub : clafer.getSubs()) {
-            Card subGlobalCard = globalCardMap.get(sub);
-            if (subGlobalCard == null) {
-                // This is possible if a child of an abstract extends the abstract.
-                // Assume the worst possible case.
-                subGlobalCard = new Card(0, analysis.getScope(sub));
+        Card globalCard;
+        if (AstUtil.isRoot(clafer)) {
+            globalCard = new Card(1, 1);
+        } else {
+            globalCard = new Card(0, 0);
+            for (AstClafer sub : clafer.getSubs()) {
+                Card subGlobalCard = globalCardMap.get(sub);
+                if (subGlobalCard == null) {
+                    // This is possible if a child of an abstract extends the abstract.
+                    // Assume the worst possible case.
+                    subGlobalCard = new Card(0, analysis.getScope(sub));
+                }
+                globalCard = globalCard.add(subGlobalCard);
             }
-            globalCard = globalCard.add(subGlobalCard);
         }
         globalCardMap.put(clafer, globalCard);
     }

--- a/src/main/java/org/clafer/ast/analysis/OptimizerAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/OptimizerAnalyzer.java
@@ -61,11 +61,12 @@ public class OptimizerAnalyzer extends AstExprRewriter<Analysis> implements Anal
     public AstExpr visit(AstJoin ast, Analysis a) {
         if (ast.getRight() instanceof AstChildRelation) {
             AstSetExpr left = rewrite(ast.getLeft(), a);
-            AstConcreteClafer right = ((AstChildRelation) ast.getRight()).getChildType();
+            AstClafer right = ((AstChildRelation) ast.getRight()).getChildType();
             if (left instanceof AstGlobal) {
                 return global(right);
-            } else if (left instanceof AstConstant) {
-                Card childCard = a.getCard(right);
+            } else if (left instanceof AstConstant && right instanceof AstConcreteClafer) {
+                // TODO what if right is abstract?
+                Card childCard = a.getCard((AstConcreteClafer) right);
                 if (Format.ParentGroup.equals(a.getFormat(right))) {
                     AstConstant constant = (AstConstant) left;
                     if (constant.getType().arity() == 1) {

--- a/src/main/java/org/clafer/ast/analysis/PartialIntAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/PartialIntAnalyzer.java
@@ -186,7 +186,11 @@ public class PartialIntAnalyzer implements Analyzer {
             AstJoin join = ((AstJoin) exp);
             AstSetExpr right = join.getRight();
             if (right instanceof AstChildRelation) {
-                return cons(((AstChildRelation) right).getChildType(), analyze(join.getLeft()));
+                AstChildRelation relation = (AstChildRelation) right;
+                // TODO what if is abstract not concrete?
+                if (relation.getChildType() instanceof AstConcreteClafer) {
+                    return cons((AstConcreteClafer) relation.getChildType(), analyze(join.getLeft()));
+                }
             }
         } else if (exp instanceof AstThis || exp instanceof AstGlobal) {
             return empty();

--- a/src/main/java/org/clafer/ast/analysis/PartialIntAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/PartialIntAnalyzer.java
@@ -15,6 +15,7 @@ import org.clafer.ast.AstClafer;
 import org.clafer.ast.AstConcreteClafer;
 import org.clafer.ast.AstConstant;
 import org.clafer.ast.AstConstraint;
+import org.clafer.ast.AstExpr;
 import org.clafer.ast.AstGlobal;
 import org.clafer.ast.AstIntClafer;
 import org.clafer.ast.AstJoin;
@@ -22,6 +23,7 @@ import org.clafer.ast.AstJoinRef;
 import org.clafer.ast.AstRef;
 import org.clafer.ast.AstSetExpr;
 import org.clafer.ast.AstSetTest;
+import org.clafer.ast.AstTernary;
 import org.clafer.ast.AstThis;
 import org.clafer.ast.AstUpcast;
 import org.clafer.ast.AstUtil;
@@ -43,13 +45,14 @@ public class PartialIntAnalyzer implements Analyzer {
         Map<AstRef, Domain[]> partialInts = new HashMap<>();
 
         List<Pair<FList<AstConcreteClafer>, Domain>> assignments = new ArrayList<>();
-        for (AstConstraint constraint : analysis.getConstraints()) {
-            AstClafer clafer = constraint.getContext();
+        for (Entry<AstConstraint, AstBoolExpr> pair : analysis.getConstraintExprs().entrySet()) {
+            AstConstraint constraint = pair.getKey();
             if (analysis.isSoft(constraint)) {
                 continue;
             }
+            AstClafer clafer = constraint.getContext();
             try {
-                Map<FList<AstConcreteClafer>, Domain> assignment = analyze(analysis.getExpr(constraint));
+                Map<FList<AstConcreteClafer>, Domain> assignment = analyze(pair.getValue());
                 for (Entry<FList<AstConcreteClafer>, Domain> entry : assignment.entrySet()) {
                     FList<AstConcreteClafer> path = entry.getKey();
                     Domain value = entry.getValue();
@@ -138,11 +141,14 @@ public class PartialIntAnalyzer implements Analyzer {
         if (expr instanceof AstSetTest) {
             AstSetTest compare = (AstSetTest) expr;
             if (AstSetTest.Op.Equal.equals(compare.getOp())) {
-                if (compare.getLeft() instanceof AstJoinRef && compare.getRight() instanceof AstConstant) {
-                    return analyzeEqual((AstJoinRef) compare.getLeft(), (AstConstant) compare.getRight());
-                }
-                if (compare.getRight() instanceof AstJoinRef && compare.getLeft() instanceof AstConstant) {
-                    return analyzeEqual((AstJoinRef) compare.getRight(), (AstConstant) compare.getLeft());
+                try {
+                    if (compare.getLeft() instanceof AstJoinRef) {
+                        return analyzeEqual((AstJoinRef) compare.getLeft(), compare.getRight());
+                    }
+                } catch (NotAssignmentException e) {
+                    if (compare.getRight() instanceof AstJoinRef) {
+                        return analyzeEqual((AstJoinRef) compare.getRight(), compare.getLeft());
+                    }
                 }
             }
         } else if (expr instanceof AstBoolArithm) {
@@ -164,15 +170,25 @@ public class PartialIntAnalyzer implements Analyzer {
         throw new NotAssignmentException();
     }
 
-    private static Map<FList<AstConcreteClafer>, Domain> analyzeEqual(
-            AstJoinRef exp, AstConstant constant) throws NotAssignmentException {
-        if (constant.getType().arity() == 1) {
-            int[] value = constant.getValue()[0];
-            if (value.length == 1) {
-                return Collections.singletonMap(analyze(exp), Domains.constantDomain(value[0]));
+    private static Domain analyzeDomain(AstExpr expr) throws NotAssignmentException {
+        if (expr instanceof AstConstant) {
+            AstConstant constant = (AstConstant) expr;
+            if (constant.getType().arity() == 1) {
+                int[] constantValue = constant.getValue()[0];
+                if (constantValue.length == 1) {
+                    return Domains.constantDomain(constantValue[0]);
+                }
             }
+        } else if (expr instanceof AstTernary) {
+            AstTernary ternary = (AstTernary) expr;
+            return analyzeDomain(ternary.getConsequent()).union(analyzeDomain(ternary.getAlternative()));
         }
         throw new NotAssignmentException();
+    }
+
+    private static Map<FList<AstConcreteClafer>, Domain> analyzeEqual(
+            AstJoinRef var, AstExpr value) throws NotAssignmentException {
+        return Collections.singletonMap(analyze(var), analyzeDomain(value));
     }
 
     private static FList<AstConcreteClafer> analyze(AstJoinRef exp) throws NotAssignmentException {

--- a/src/main/java/org/clafer/ast/analysis/ScopeAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/ScopeAnalyzer.java
@@ -23,7 +23,7 @@ public class ScopeAnalyzer implements Analyzer {
     public Analysis analyze(Analysis analysis) {
         Scope scope = analysis.getScope();
         Map<AstClafer, Integer> optimizedScope = new HashMap<>();
-        optimizedScope.put(analysis.getModel(), 1);
+        optimizedScope.put(analysis.getModel().getRoot(), 1);
 
         for (Set<AstClafer> component : analysis.getClafersInParentAndSubOrder()) {
             for (AstClafer clafer : component) {

--- a/src/main/java/org/clafer/ast/analysis/SymmetryAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/SymmetryAnalyzer.java
@@ -46,7 +46,7 @@ public class SymmetryAnalyzer implements Analyzer {
         for (AstAbstractClafer clafer : analysis.getAbstractClafers()) {
             breakableChildren(clafer, breakableChildren, analysis);
         }
-        breakableChildren(analysis.getModel(), breakableChildren, analysis);
+        breakableChildren(analysis.getModel().getRoot(), breakableChildren, analysis);
         return analysis.setBreakableChildrenMap(breakableChildren);
     }
 

--- a/src/main/java/org/clafer/ast/analysis/TypeAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/TypeAnalyzer.java
@@ -652,7 +652,7 @@ public class TypeAnalyzer implements Analyzer {
 
         @Override
         public TypedExpr<?> visit(AstChildRelation ast, Void a) {
-            AstConcreteClafer child = ast.getChildType();
+            AstClafer child = ast.getChildType();
             if (!child.hasParent()) {
                 throw new TypeException(child + " does not have a parent");
             }

--- a/src/main/java/org/clafer/ast/analysis/TypeAnalyzer.java
+++ b/src/main/java/org/clafer/ast/analysis/TypeAnalyzer.java
@@ -120,7 +120,7 @@ public class TypeAnalyzer implements Analyzer {
         Map<Objective, AstSetExpr> objectives = analysis.getObjectiveExprs();
         Map<Objective, AstSetExpr> typedObjectives = new HashMap<>(objectives.size());
         for (Entry<Objective, AstSetExpr> objective : objectives.entrySet()) {
-            TypeVisitor visitor = new TypeVisitor(Type.basicType(analysis.getModel()), typeMap);
+            TypeVisitor visitor = new TypeVisitor(Type.basicType(analysis.getModel().getAbstractRoot()), typeMap);
             TypedExpr<AstSetExpr> typedObjective = visitor.typeCheck(objective.getValue());
             if (!typedObjective.getCommonSupertype().isInt()) {
                 throw new TypeException("Cannot optimize on " + typedObjective.getType());
@@ -130,7 +130,7 @@ public class TypeAnalyzer implements Analyzer {
         Map<Assertion, AstBoolExpr> assertions = analysis.getAssertionExprs();
         Map<Assertion, AstBoolExpr> typedAssertions = new HashMap<>(assertions.size());
         for (Entry<Assertion, AstBoolExpr> assertion : assertions.entrySet()) {
-            TypeVisitor visitor = new TypeVisitor(Type.basicType(analysis.getModel()), typeMap);
+            TypeVisitor visitor = new TypeVisitor(Type.basicType(analysis.getModel().getAbstractRoot()), typeMap);
             TypedExpr<AstBoolExpr> typedAssertion = visitor.typeCheck(assertion.getValue());
             if (!typedAssertion.getCommonSupertype().isBool()) {
                 throw new TypeException("Cannot assert on " + typedAssertion.getType());

--- a/src/main/java/org/clafer/ast/compiler/AstCompiler.java
+++ b/src/main/java/org/clafer/ast/compiler/AstCompiler.java
@@ -1494,9 +1494,12 @@ public class AstCompiler {
                     }
                     return product;
                 case Div:
+                    member = memberships.get(thisType)[thisId];
                     IrIntExpr quotient = operands[0];
                     for (int i = 1; i < operands.length; i++) {
-                        quotient = div(quotient, operands[i]);
+                        IrIntExpr operand = operands[i];
+                        quotient = div(quotient,
+                                operand.getDomain().contains(0) ? ternary(member, operand, One) : operand);
                     }
                     return quotient;
                 default:

--- a/src/main/java/org/clafer/ast/compiler/AstCompiler.java
+++ b/src/main/java/org/clafer/ast/compiler/AstCompiler.java
@@ -1212,11 +1212,12 @@ public class AstCompiler {
                 IrSetExpr[] array = new IrSetExpr[getScope(right.getParent())];
                 Arrays.fill(array, EmptySet);
                 for (AstClafer sub : abstractRight.getSubs()) {
-                    IrSetVar[] subSiblingSet = siblingSets.get(sub);
                     int offset = getOffset(abstractRight, sub);
-                    assert array.length == subSiblingSet.length;
-                    for (int i = 0; i < array.length; i++) {
-                        array[i] = unionDisjoint(array[i], offset(subSiblingSet[i], offset));
+                    int parentOffset = getOffset(abstractRight.getParent(), sub.getParent());
+                    IrSetVar[] subSiblingSet = siblingSets.get(sub);
+                    for (int i = 0; i < subSiblingSet.length; i++) {
+                        array[i + parentOffset] = unionDisjoint(array[i + parentOffset],
+                                offset(subSiblingSet[i], offset));
                     }
                 }
                 rightArray = array(array);

--- a/src/main/java/org/clafer/ast/compiler/AstCompiler.java
+++ b/src/main/java/org/clafer/ast/compiler/AstCompiler.java
@@ -280,9 +280,9 @@ public class AstCompiler {
 
     private AstSolutionMap compile() {
         IrSetVar rootSet = constant(new int[]{0});
-        sets.put(analysis.getModel(), rootSet);
-        siblingSets.put(analysis.getModel(), new IrSetVar[]{rootSet});
-        memberships.put(analysis.getModel(), new IrBoolVar[]{True});
+        sets.put(analysis.getModel().getRoot(), rootSet);
+        siblingSets.put(analysis.getModel().getRoot(), new IrSetVar[]{rootSet});
+        memberships.put(analysis.getModel().getRoot(), new IrBoolVar[]{True});
 
         List<AstClafer> clafers = initOrder();
         for (AstClafer clafer : clafers) {

--- a/src/main/java/org/clafer/ast/compiler/AstCompiler.java
+++ b/src/main/java/org/clafer/ast/compiler/AstCompiler.java
@@ -1490,11 +1490,7 @@ public class AstCompiler {
                         if (!mulBoundDomain.isSubsetOf(mulRange)) {
                             operand = ternary(member, operands[i], Zero);
                         }
-                        try {
-                            product = mul(product, operand, mulRange);
-                        } catch (IllegalIntException e) {
-                            throw new UnsatisfiableException(e);
-                        }
+                        product = mul(product, operand, mulRange);
                     }
                     return product;
                 case Div:

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSet.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropArrayToSet.java
@@ -137,7 +137,7 @@ public class PropArrayToSet extends Propagator<Variable> {
             int id = getAVarIndex(idxVarInProp);
             if (IntEventType.isRemove(mask)
                     || (IntEventType.isInclow(mask) && as[id].getLB() > s.getEnvelopeFirst())
-                    || IntEventType.isDecupp(mask)) {
+                    || IntEventType.isDecupp(mask) || IntEventType.isInstantiate(mask)) {
                 asD[id].freeze();
                 asD[id].forEachRemVal((IntProcedure) aRem -> {
                     if (s.envelopeContains(aRem)) {

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunction.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunction.java
@@ -150,6 +150,7 @@ public class PropJoinFunction extends Propagator<Variable> {
 
         // Prune to
         findMates();
+        takeD.unfreeze();
     }
 
     @Override

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunctionCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinFunctionCard.java
@@ -82,7 +82,6 @@ public class PropJoinFunctionCard extends Propagator<Variable> {
 //        }
 //        return super.advise(idxVarInProp, mask);
 //    }
-
     @Override
     public int getPropagationConditions(int vIdx) {
         if (isTakeVar(vIdx)) {
@@ -174,6 +173,13 @@ public class PropJoinFunctionCard extends Propagator<Variable> {
     public void propagate(int evtmask) throws ContradictionException {
         takeCard.updateLowerBound(take.getKernelSize(), this);
         takeCard.updateUpperBound(take.getEnvelopeSize(), this);
+
+        for (int i = take.getEnvelopeFirst(); i != SetVar.END; i = take.getEnvelopeNext()) {
+            if (i < 0 || i >= refs.length) {
+                take.removeFromEnvelope(i, this);
+            }
+        }
+
         boolean changed;
         do {
             changed = false;

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinInjectiveRelationCard.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinInjectiveRelationCard.java
@@ -69,7 +69,6 @@ public class PropJoinInjectiveRelationCard extends Propagator<Variable> {
 //        }
 //        return super.advise(idxVarInProp, mask);
 //    }
-
     @Override
     public int getPropagationConditions(int vIdx) {
         if (isTakeVar(vIdx)) {
@@ -81,6 +80,12 @@ public class PropJoinInjectiveRelationCard extends Propagator<Variable> {
 
     @Override
     public void propagate(int evtmask) throws ContradictionException {
+        for (int i = take.getEnvelopeFirst(); i != SetVar.END; i = take.getEnvelopeNext()) {
+            if (i < 0 || i >= childrenCards.length) {
+                take.removeFromEnvelope(i, this);
+            }
+        }
+
         boolean changed;
         do {
             int minCard = 0;

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropJoinRelation.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropJoinRelation.java
@@ -140,6 +140,7 @@ public class PropJoinRelation extends Propagator<SetVar> {
         for (int i = to.getEnvelopeFirst(); i != SetVar.END; i = to.getEnvelopeNext()) {
             findMate(i);
         }
+        takeD.unfreeze();
     }
 
     @Override

--- a/src/main/java/org/clafer/choco/constraint/propagator/PropLength.java
+++ b/src/main/java/org/clafer/choco/constraint/propagator/PropLength.java
@@ -68,10 +68,10 @@ public class PropLength extends Propagator<IntVar> {
     @Override
     public void propagate(int idxVarInProp, int mask) throws ContradictionException {
         if (isLengthVar(idxVarInProp)) {
-            if (IntEventType.isInclow(mask)) {
+            if (IntEventType.isInclow(mask) || IntEventType.isInstantiate(mask)) {
                 onLengthLB();
             }
-            if (IntEventType.isDecupp(mask)) {
+            if (IntEventType.isDecupp(mask) || IntEventType.isInstantiate(mask)) {
                 onLengthUB();
             }
         } else {

--- a/src/main/java/org/clafer/cli/Normal.java
+++ b/src/main/java/org/clafer/cli/Normal.java
@@ -35,7 +35,7 @@ public class Normal {
         Scope scope = Utils.resolveScopes(javascriptFile, options);
 
         // handle search strategy
-        ClaferOption compilerOption = ClaferOption.Default;
+        ClaferOption compilerOption = javascriptFile.getOption();
         if (options.has("search"))
             compilerOption = compilerOption.setStrategy((ClaferSearchStrategy) options.valueOf("search"));
 

--- a/src/main/java/org/clafer/cli/REPL.java
+++ b/src/main/java/org/clafer/cli/REPL.java
@@ -103,7 +103,7 @@ public class REPL {
 
         Scope scope = Utils.resolveScopes(javascriptFile, options);
 
-        ClaferOption compilerOption = ClaferOption.Default;
+        ClaferOption compilerOption = javascriptFile.getOption();
         if (options.has("search"))
             compilerOption = compilerOption.setStrategy((ClaferSearchStrategy) options.valueOf("search"));
 

--- a/src/main/java/org/clafer/cli/Utils.java
+++ b/src/main/java/org/clafer/cli/Utils.java
@@ -185,7 +185,7 @@ public static InstanceClafer getInstanceValueByName(InstanceClafer[] topClafers,
     }
 
     private static void printClafer(InstanceClafer clafer, String indent, Appendable out) throws IOException {
-        out.append(indent).append(clafer.getType().getName()).append('$').append(Integer.toString(clafer.getId()));
+        out.append(indent).append(clafer.getType().getName()).append(countSuffix(clafer.getId()));
 
         if (clafer.getType().getSuperClafer() != null) {
             String name = clafer.getType().getSuperClafer().getName();
@@ -198,7 +198,7 @@ public static InstanceClafer getInstanceValueByName(InstanceClafer[] topClafers,
             out.append(" -> " + AstUtil.getInheritedRef(clafer.getType()).getTargetType().getName() + " = ");
             if (clafer.getRef() instanceof InstanceClafer) {
                 InstanceClafer refClafer = (InstanceClafer) clafer.getRef();
-                out.append(refClafer.getType().getName()).append('$').append(Integer.toString(refClafer.getId()));
+                out.append(refClafer.getType().getName()).append(countSuffix(refClafer.getId()));
             } else
                 out.append(clafer.getRef().toString());
         }
@@ -208,6 +208,14 @@ public static InstanceClafer getInstanceValueByName(InstanceClafer[] topClafers,
             printClafer(child, indent + "  ", out);
         }
     }
+
+    public static String countSuffix(int count) {
+        return count == 0 ? "" : "$" + Integer.toString(count);
+    }
+    public static String simpleName(String fullName) {
+        return fullName.substring(fullName.indexOf('_')+1);
+    }
+
     public static Scope resolveScopes(JavascriptFile javascriptFile, OptionSet options) {
         Scope scope = javascriptFile.getScope();
         if (options.has("scope"))

--- a/src/main/java/org/clafer/cli/Validate.java
+++ b/src/main/java/org/clafer/cli/Validate.java
@@ -42,7 +42,7 @@ public class Validate {
             compilerOption = compilerOption.setStrategy((ClaferSearchStrategy) options.valueOf("search"));
         }
 
-        ClaferAsserter solver = ClaferCompiler.compile(javascriptFile.getModel(), scope, assertions);
+        ClaferAsserter solver = ClaferCompiler.compile(javascriptFile.getModel(), scope, assertions, javascriptFile.getOption());
 
         int index = 0; // optimal instance id
         boolean prettify = options.has("prettify");

--- a/src/main/java/org/clafer/common/Util.java
+++ b/src/main/java/org/clafer/common/Util.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Random;
 import org.chocosolver.util.iterators.IntIterator;
 
@@ -353,6 +354,19 @@ public class Util {
         int[] r = Arrays.copyOf(array, array.length + 1);
         r[array.length] = item;
         return r;
+    }
+
+    /**
+     * Functional-programming cons if head is present. Nondestructive.
+     *
+     * @param <T> the type of the elements
+     * @param head the beginning of the new list if present
+     * @param tail the end of the new list
+     * @return a copy of the original list with head appended at the start if
+     * present, otherwise a copy of tail
+     */
+    public static <T> List<T> maybeCons(Optional<T> head, List<? extends T> tail) {
+        return head.map(h -> cons(h, tail)).orElse(new ArrayList<>(tail));
     }
 
     /**

--- a/src/main/java/org/clafer/compiler/ClaferOption.java
+++ b/src/main/java/org/clafer/compiler/ClaferOption.java
@@ -1,5 +1,7 @@
 package org.clafer.compiler;
 
+import java.util.Set;
+import org.clafer.ast.AstClafer;
 import org.clafer.common.Check;
 
 /**
@@ -13,16 +15,29 @@ import org.clafer.common.Check;
 public class ClaferOption {
 
     private final ClaferSearchStrategy strategy;
-    /*
-     * true: basic symmetry breaking
-     * false: full symmetry breaking
+    /**
+     * If true then basic symmetry breaking, else full symmetry breaking.
      */
     private final boolean basicSymmetryBreaking;
-    /*
-     * true: basic optimizations
-     * false: full optimizations
+    /**
+     * If true then basic optimizations else full optimizations.
      */
     private final boolean basicOptimizations;
+    /**
+     * The branching heuristic will use the priorities to determine the order of
+     * branching.
+     *
+     * For example, consider the priorities [{a,b}, {c,d}, {e}]. This forces the
+     * branching heuristic to branch on either a or b. Once both a and b are
+     * assigned, then the branching heuristic will branch on either c or d. Once
+     * all a, b, c, and d are assigned then the branching heuristic will branch
+     * on e. Once all a, b, c, d, and e are assigned, then the branching
+     * heuristic will branch on the remaining Clafers.
+     *
+     * Assumes that the sets in this array are all pairwise disjoint.
+     */
+    private final Set<AstClafer>[] branchingPriority;
+
     /**
      * Use the default options.
      */
@@ -30,10 +45,15 @@ public class ClaferOption {
     public static final ClaferOption Basic = new ClaferOption(ClaferSearchStrategy.PreferSmallerInstances, true, true);
     public static final ClaferOption Default = Optimized;
 
-    private ClaferOption(ClaferSearchStrategy strategy, boolean basicSymmetryBreaking, boolean basicOptimizations) {
+    private ClaferOption(ClaferSearchStrategy strategy, boolean basicSymmetryBreaking, boolean basicOptimizations, Set<AstClafer>[] branchingPriority) {
         this.strategy = Check.notNull(strategy);
         this.basicSymmetryBreaking = basicSymmetryBreaking;
         this.basicOptimizations = basicOptimizations;
+        this.branchingPriority = branchingPriority;
+    }
+
+    private ClaferOption(ClaferSearchStrategy strategy, boolean basicSymmetryBreaking, boolean basicOptimizations) {
+        this(strategy, basicSymmetryBreaking, basicOptimizations, new Set[0]);
     }
 
     public ClaferSearchStrategy getStrategy() {
@@ -74,6 +94,14 @@ public class ClaferOption {
 
     public ClaferOption fullOptimizations() {
         return new ClaferOption(strategy, basicSymmetryBreaking, false);
+    }
+
+    public Set<AstClafer>[] getBranchingPriority() {
+        return branchingPriority;
+    }
+
+    public ClaferOption setBranchingPriority(Set<AstClafer>... branchingPriority) {
+        return new ClaferOption(strategy, basicSymmetryBreaking, basicOptimizations, branchingPriority);
     }
 
     @Override

--- a/src/main/java/org/clafer/compiler/ClaferOption.java
+++ b/src/main/java/org/clafer/compiler/ClaferOption.java
@@ -26,15 +26,6 @@ public class ClaferOption {
     /**
      * The branching heuristic will use the priorities to determine the order of
      * branching.
-     *
-     * For example, consider the priorities [{a,b}, {c,d}, {e}]. This forces the
-     * branching heuristic to branch on either a or b. Once both a and b are
-     * assigned, then the branching heuristic will branch on either c or d. Once
-     * all a, b, c, and d are assigned then the branching heuristic will branch
-     * on e. Once all a, b, c, d, and e are assigned, then the branching
-     * heuristic will branch on the remaining Clafers.
-     *
-     * Assumes that the sets in this array are all pairwise disjoint.
      */
     private final Set<AstClafer>[] branchingPriority;
 
@@ -100,6 +91,21 @@ public class ClaferOption {
         return branchingPriority;
     }
 
+    /**
+     * Specify priorities of Clafers for branching.
+     *
+     * For example, consider the priorities [{a,b}, {c,d}, {e}]. This forces the
+     * branching heuristic to branch on either a or b. Once both a and b are
+     * assigned, then the branching heuristic will branch on either c or d. Once
+     * all a, b, c, and d are assigned then the branching heuristic will branch
+     * on e. Once all a, b, c, d, and e are assigned, then the branching
+     * heuristic will branch on the remaining Clafers.
+     *
+     * Assumes that the sets in this array are all pairwise disjoint.
+     *
+     * @param branchingPriority
+     * @return
+     */
     public ClaferOption setBranchingPriority(Set<AstClafer>... branchingPriority) {
         return new ClaferOption(strategy, basicSymmetryBreaking, basicOptimizations, branchingPriority);
     }

--- a/src/main/java/org/clafer/domain/BoundDomain.java
+++ b/src/main/java/org/clafer/domain/BoundDomain.java
@@ -55,7 +55,8 @@ public class BoundDomain implements Domain {
 
     @Override
     public int size() {
-        return high + 1 - low;
+        long size = (long) high + 1 - low;
+        return size >= Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) size;
     }
 
     @Override

--- a/src/main/java/org/clafer/instance/InstanceClafer.java
+++ b/src/main/java/org/clafer/instance/InstanceClafer.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import org.clafer.ast.AstClafer;
 import org.clafer.ast.AstConcreteClafer;
 import org.clafer.common.Check;
+import org.clafer.cli.Utils;
 
 /**
  *
@@ -81,12 +82,12 @@ public class InstanceClafer {
     }
 
     private void print(String indent, Appendable out) throws IOException {
-        out.append(indent).append(getType().getName()).append('$').append(Integer.toString(getId()));
+        out.append(indent).append(Utils.simpleName(getType().getName())).append(Utils.countSuffix(getId()));
         if (hasRef()) {
-            out.append(" = ");
+            out.append(" -> ");
             if (getRef() instanceof InstanceClafer) {
                 InstanceClafer refClafer = (InstanceClafer) getRef();
-                out.append(refClafer.getType().getName()).append('$').append(Integer.toString(refClafer.getId()));
+                out.append(Utils.simpleName(refClafer.getType().getName())).append(Utils.countSuffix(refClafer.getId()));
             } else {
                 out.append(getRef().toString());
             }

--- a/src/main/java/org/clafer/ir/IrMul.java
+++ b/src/main/java/org/clafer/ir/IrMul.java
@@ -4,7 +4,7 @@ import org.clafer.domain.Domain;
 import org.clafer.common.Check;
 
 /**
- * multiplicant * multiplier
+ * multiplicand * multiplier
  *
  * @author jimmy
  */
@@ -16,6 +16,13 @@ public class IrMul extends IrAbstractInt {
      * Choco easier.
      */
     private final IrIntExpr multiplicand, multiplier;
+    /**
+     * The intRange explicitly limits the domain of the multiplication. That is
+     * it must be the case that domain is a subset of intRange. This intRange
+     * needs to be stored so that any rewriting of the multiplication will
+     * remember the limit. Note that this limit is only a recommendation and is
+     * typically set by the end user to avoid excessive memory usage.
+     */
     private final Domain intRange;
 
     IrMul(IrIntExpr multiplicand, IrIntExpr multiplier, Domain intRange, Domain domain) {

--- a/src/main/java/org/clafer/ir/Irs.java
+++ b/src/main/java/org/clafer/ir/Irs.java
@@ -1416,6 +1416,9 @@ public class Irs {
         } else {
             domain = mulBoundDomain(multiplicand.getDomain(), multiplier.getDomain()).intersection(intRange);
         }
+        if (domain.isEmpty()) {
+            throw new UnsatisfiableException();
+        }
         return new IrMul(multiplicand, multiplier, intRange, domain);
     }
 
@@ -1465,6 +1468,9 @@ public class Irs {
             return dividend;
         }
         if (dividendConstant != null && divisorConstant != null) {
+            if (divisorConstant == 0) {
+                throw new UnsatisfiableException();
+            }
             return constant(dividendConstant / divisorConstant);
         }
         int low = dividend.getDomain().getLowBound();

--- a/src/main/java/org/clafer/ir/Irs.java
+++ b/src/main/java/org/clafer/ir/Irs.java
@@ -1394,17 +1394,39 @@ public class Irs {
         if (multiplicandConstant != null && multiplierConstant != null) {
             return constant(multiplicandConstant * multiplierConstant);
         }
-        int low1 = multiplicand.getDomain().getLowBound();
-        int high1 = multiplicand.getDomain().getHighBound();
-        int low2 = multiplier.getDomain().getLowBound();
-        int high2 = multiplier.getDomain().getHighBound();
-        int ll = mulTwo(low1, low2);
-        int lh = mulTwo(low1, high2);
-        int hl = mulTwo(high1, low2);
-        int hh = mulTwo(high1, high2);
-        int min = Util.min(ll, lh, hl, hh);
-        int max = Util.max(ll, lh, hl, hh);
-        return new IrMul(multiplicand, multiplier, intRange, intRange.boundBetween(min, max));
+        Domain domain;
+        long m0 = multiplicand.getDomain().size();
+        long m1 = multiplier.getDomain().size();
+        if (m0 * m1 <= 16 || m0 * m1 <= intRange.size()) {
+            TIntSet domainSet = new TIntHashSet();
+            TIntIterator iter0 = multiplicand.getDomain().iterator();
+            while (iter0.hasNext()) {
+                long i0 = iter0.next();
+                TIntIterator iter1 = multiplier.getDomain().iterator();
+                while (iter1.hasNext()) {
+                    long i1 = iter1.next();
+                    long mul = i0 * i1;
+                    int mulI = (int) mul;
+                    if (mul == mulI) {
+                        domainSet.add(mulI);
+                    }
+                }
+            }
+            domain = enumDomain(domainSet);
+        } else {
+            int low1 = multiplicand.getDomain().getLowBound();
+            int high1 = multiplicand.getDomain().getHighBound();
+            int low2 = multiplier.getDomain().getLowBound();
+            int high2 = multiplier.getDomain().getHighBound();
+            int ll = mulTwo(low1, low2);
+            int lh = mulTwo(low1, high2);
+            int hl = mulTwo(high1, low2);
+            int hh = mulTwo(high1, high2);
+            int min = Util.min(ll, lh, hl, hh);
+            int max = Util.max(ll, lh, hl, hh);
+            domain = intRange.boundBetween(min, max);
+        }
+        return new IrMul(multiplicand, multiplier, intRange, domain);
     }
 
     public static IrIntExpr mul(IrIntExpr[] multiplicands, Domain intRange) {

--- a/src/main/java/org/clafer/ir/Irs.java
+++ b/src/main/java/org/clafer/ir/Irs.java
@@ -2028,6 +2028,10 @@ public class Irs {
         return union(operands, false);
     }
 
+    public static IrSetExpr unionDisjoint(IrSetExpr... operands) {
+        return union(operands, true);
+    }
+
     public static IrSetExpr union(IrSetExpr[] operands, boolean disjoint) {
         List<IrSetExpr> flatten = new ArrayList<>(operands.length);
         for (IrSetExpr operand : operands) {

--- a/src/main/java/org/clafer/ir/Irs.java
+++ b/src/main/java/org/clafer/ir/Irs.java
@@ -1414,19 +1414,23 @@ public class Irs {
             }
             domain = enumDomain(domainSet);
         } else {
-            int low1 = multiplicand.getDomain().getLowBound();
-            int high1 = multiplicand.getDomain().getHighBound();
-            int low2 = multiplier.getDomain().getLowBound();
-            int high2 = multiplier.getDomain().getHighBound();
-            int ll = mulTwo(low1, low2);
-            int lh = mulTwo(low1, high2);
-            int hl = mulTwo(high1, low2);
-            int hh = mulTwo(high1, high2);
-            int min = Util.min(ll, lh, hl, hh);
-            int max = Util.max(ll, lh, hl, hh);
-            domain = intRange.boundBetween(min, max);
+            domain = mulBoundDomain(multiplicand.getDomain(), multiplier.getDomain()).intersection(intRange);
         }
         return new IrMul(multiplicand, multiplier, intRange, domain);
+    }
+
+    public static Domain mulBoundDomain(Domain multiplicandDomain, Domain multiplierDomain) {
+        int low1 = multiplicandDomain.getLowBound();
+        int high1 = multiplicandDomain.getHighBound();
+        int low2 = multiplierDomain.getLowBound();
+        int high2 = multiplierDomain.getHighBound();
+        int ll = mulTwo(low1, low2);
+        int lh = mulTwo(low1, high2);
+        int hl = mulTwo(high1, low2);
+        int hh = mulTwo(high1, high2);
+        return boundDomain(
+                Util.min(ll, lh, hl, hh),
+                Util.max(ll, lh, hl, hh));
     }
 
     public static IrIntExpr mul(IrIntExpr[] multiplicands, Domain intRange) {

--- a/src/main/java/org/clafer/ir/analysis/LinearEquationOptimizer.java
+++ b/src/main/java/org/clafer/ir/analysis/LinearEquationOptimizer.java
@@ -135,7 +135,7 @@ public class LinearEquationOptimizer {
                 new LinearEquation(equation.getLeft().mul(lcm), equation.getOp(), equation.getRight().mul(lcm), false)
             };
         }
-        long multiplier = Math.min(Math.abs(50000 / max.ceil()), Math.abs(50000 / min.floor()));
+        long multiplier = 50000 / Math.max(Math.abs(max.ceil()), Math.abs(min.floor()));
         if (multiplier == 0) {
             multiplier = 1;
         }

--- a/src/main/java/org/clafer/ir/compiler/IrCompiler.java
+++ b/src/main/java/org/clafer/ir/compiler/IrCompiler.java
@@ -1780,9 +1780,6 @@ public class IrCompiler {
     }
 
     private static Constraint _div(IntVar dividend, IntVar divisor, IntVar quotient) {
-        if (divisor.contains(0)) {
-            divisor.getSolver().post(_arithm(divisor, "!=", 0));
-        }
         return ICF.eucl_div(dividend, divisor, quotient);
     }
 

--- a/src/main/java/org/clafer/javascript/Javascript.java
+++ b/src/main/java/org/clafer/javascript/Javascript.java
@@ -62,6 +62,7 @@ public class Javascript {
             return new JavascriptFile(
                     context.getModel(),
                     context.getScope(engine),
+                    context.getClaferOption(),
                     context.getObjectives(),
                     context.getAssertions());
         } finally {
@@ -86,6 +87,7 @@ public class Javascript {
             return new JavascriptFile(
                     context.getModel(),
                     context.getScope(engine),
+                    context.getClaferOption(),
                     context.getObjectives(),
                     context.getAssertions());
         } finally {

--- a/src/main/java/org/clafer/javascript/JavascriptContext.java
+++ b/src/main/java/org/clafer/javascript/JavascriptContext.java
@@ -1,16 +1,20 @@
 package org.clafer.javascript;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import org.clafer.assertion.Assertion;
 import org.clafer.ast.AstBoolExpr;
 import org.clafer.ast.AstClafer;
 import org.clafer.ast.AstModel;
 import org.clafer.ast.AstSetExpr;
 import org.clafer.ast.Asts;
+import org.clafer.compiler.ClaferOption;
 import org.clafer.objective.Objective;
 import org.clafer.scope.Scope;
 import org.clafer.scope.ScopeBuilder;
@@ -28,6 +32,7 @@ public class JavascriptContext {
     private final ScopeBuilder scopeBuilder = Scope.builder();
     private final List<Objective> objectives = new ArrayList<>(0);
     private final List<Assertion> assertions = new ArrayList<>(0);
+    private Set<AstClafer>[] branchingPriority = new Set[0];
 
     public AstModel getModel() {
         return model;
@@ -78,6 +83,15 @@ public class JavascriptContext {
             scopeBuilder.setScope(clafer, entry.getValue());
         }
         return scopeBuilder.toScope();
+    }
+
+    public void setBranchingPriority(List<List<AstClafer>> branchingPriority) {
+        this.branchingPriority = branchingPriority.stream().map(HashSet::new).toArray(x -> new Set[x]);
+        System.out.println(Arrays.toString(this.branchingPriority));
+    }
+
+    public ClaferOption getClaferOption() {
+        return ClaferOption.Default.setBranchingPriority(branchingPriority);
     }
 
     public void addMaximizeObjective(AstSetExpr expr) {

--- a/src/main/java/org/clafer/javascript/JavascriptContext.java
+++ b/src/main/java/org/clafer/javascript/JavascriptContext.java
@@ -87,7 +87,6 @@ public class JavascriptContext {
 
     public void setBranchingPriority(List<List<AstClafer>> branchingPriority) {
         this.branchingPriority = branchingPriority.stream().map(HashSet::new).toArray(x -> new Set[x]);
-        System.out.println(Arrays.toString(this.branchingPriority));
     }
 
     public ClaferOption getClaferOption() {

--- a/src/main/java/org/clafer/javascript/JavascriptFile.java
+++ b/src/main/java/org/clafer/javascript/JavascriptFile.java
@@ -2,6 +2,7 @@ package org.clafer.javascript;
 
 import org.clafer.assertion.Assertion;
 import org.clafer.ast.AstModel;
+import org.clafer.compiler.ClaferOption;
 import org.clafer.objective.Objective;
 import org.clafer.scope.Scope;
 
@@ -13,12 +14,14 @@ public class JavascriptFile {
 
     private final AstModel model;
     private final Scope scope;
+    private final ClaferOption option;
     private final Objective[] objectives;
     private final Assertion[] assertions;
 
-    public JavascriptFile(AstModel model, Scope scope, Objective[] objectives, Assertion[] assertions) {
+    public JavascriptFile(AstModel model, Scope scope, ClaferOption option, Objective[] objectives, Assertion[] assertions) {
         this.model = model;
         this.scope = scope;
+        this.option = option;
         this.objectives = objectives;
         this.assertions = assertions;
     }
@@ -29,6 +32,10 @@ public class JavascriptFile {
 
     public Scope getScope() {
         return scope;
+    }
+
+    public ClaferOption getOption() {
+        return option;
     }
 
     public Objective[] getObjectives() {

--- a/src/main/java/org/clafer/math/LinearEquation.java
+++ b/src/main/java/org/clafer/math/LinearEquation.java
@@ -32,12 +32,13 @@ public class LinearEquation {
         if (left.hasConstant()) {
             throw new IllegalArgumentException();
         }
-        if (!scale || right.isZero()) {
+        if (scale && (!right.isZero() || left.arity() > 0)) {
+            Rational divisor = right.isZero() ? left.getCoefficients()[0].abs() : right.abs();
+            this.left = left.div(divisor);
+            this.right = right.div(divisor);
+        } else {
             this.left = left;
             this.right = right;
-        } else {
-            this.left = left.div(right.abs());
-            this.right = right.div(right.abs());
         }
         this.op = op;
     }

--- a/src/main/java/org/clafer/math/LinearFunction.java
+++ b/src/main/java/org/clafer/math/LinearFunction.java
@@ -95,6 +95,10 @@ public class LinearFunction implements LinearFunctionable {
         this.coefficientMap = map;
     }
 
+    public int arity() {
+        return coefficients.length;
+    }
+
     public Rational getCoefficient(Variable variable) {
         return coefficientMap.get(variable);
     }

--- a/src/main/resources/org/clafer/javascript/header.js
+++ b/src/main/resources/org/clafer/javascript/header.js
@@ -9,6 +9,7 @@ var charRange = rc.setCharRange.bind(rc);
 var Clafer = rc.getModel().addChild.bind(rc.getModel());
 var Abstract = rc.getModel().addAbstract.bind(rc.getModel()); // Some Javascript engine versions has "abstract" as a keyword.
 var Constraint = rc.getModel().addConstraint.bind(rc.getModel());
+var branchingPriority = rc.setBranchingPriority.bind(rc);
 var max = rc.addMaximizeObjective.bind(rc);
 var min = rc.addMinimizeObjective.bind(rc);
 var assert = rc.addAssertion.bind(rc);

--- a/src/test/java/org/clafer/ArithmeticTest.java
+++ b/src/test/java/org/clafer/ArithmeticTest.java
@@ -148,6 +148,34 @@ public class ArithmeticTest {
 
     /**
      * <pre>
+     * A -> int
+     * B -> int
+     * C -> int ?
+     *     [ this.ref = A.ref * B.ref ]
+     * </pre>
+     */
+    @Test(timeout = 60000)
+    public void testOptionalMul() {
+        AstModel model = newModel();
+
+        AstConcreteClafer a = model.addChild("A").refToUnique(IntType).withCard(Mandatory);
+        AstConcreteClafer b = model.addChild("B").refToUnique(IntType).withCard(Mandatory);
+        AstConcreteClafer c = model.addChild("C").refToUnique(IntType).withCard(Optional);
+        model.addConstraint(greaterThan(joinRef(a), joinRef(b)));
+        c.addConstraint(equal(joinRef($this()), add(mul(joinRef(a), joinRef(b)), constant(1))));
+
+        ClaferSolver solver = ClaferCompiler.compile(model, Scope.defaultScope(1).intLow(0).intHigh(5));
+        while (solver.find()) {
+            InstanceModel instance = solver.instance();
+            for (InstanceClafer ci : instance.getTopClafers(c)) {
+                assertEquals(ci.getRef(), (Integer) instance.getTopClafer(a).getRef() * (Integer) instance.getTopClafer(b).getRef() + 1);
+            }
+        }
+        assertEquals(23, solver.instanceCount());
+    }
+
+    /**
+     * <pre>
      * A -> integer
      * B -> integer
      * [ 12 * A.ref = B.ref]

--- a/src/test/java/org/clafer/SimpleConstraintTest.java
+++ b/src/test/java/org/clafer/SimpleConstraintTest.java
@@ -596,4 +596,29 @@ public class SimpleConstraintTest {
         ClaferSolver solver = ClaferCompiler.compile(model, Scope.defaultScope(2));
         assertEquals(4, solver.allInstances().length);
     }
+
+    /**
+     * <pre>
+     * abstract Message
+     *     abstract Content -> int
+     * Mail : Message ?
+     *     Letter : Content
+     *     Gift : Content *
+     *     [ 1 in this.Content.ref ]
+     * </pre>
+     */
+    @Test()
+    public void testNestedAbstract() {
+        AstModel model = newModel();
+
+        AstAbstractClafer message = model.addAbstract("Message");
+        AstAbstractClafer content = message.addAbstractChild("Content").refToUnique(IntType);
+        AstConcreteClafer mail = model.addChild("Mail").extending(message).withCard(Optional);
+        AstConcreteClafer letter = mail.addChild("Letter").extending(content).withCard(Mandatory);
+        AstConcreteClafer gift = mail.addChild("Gift").extending(content);
+        mail.addConstraint(in(constant(1), joinRef(join($this(), content))));
+
+        ClaferSolver solver = ClaferCompiler.compile(model, Scope.defaultScope(2).intLow(0).intHigh(1));
+        assertEquals(7, solver.allInstances().length);
+    }
 }

--- a/src/test/java/org/clafer/SimpleConstraintTest.java
+++ b/src/test/java/org/clafer/SimpleConstraintTest.java
@@ -607,7 +607,7 @@ public class SimpleConstraintTest {
      *     [ 1 in this.Content.ref ]
      * </pre>
      */
-    @Test()
+    @Test(timeout = 60000)
     public void testNestedAbstract() {
         AstModel model = newModel();
 

--- a/src/test/java/org/clafer/SimpleStructureTest.java
+++ b/src/test/java/org/clafer/SimpleStructureTest.java
@@ -77,7 +77,7 @@ public class SimpleStructureTest {
 
     /**
      * <pre>
-     * xor Type
+     * 2..3 Type
      *     Car ?
      *     Truck ?
      *     Van ?

--- a/src/test/java/org/clafer/ast/AstUtilTest.java
+++ b/src/test/java/org/clafer/ast/AstUtilTest.java
@@ -1,0 +1,36 @@
+package org.clafer.ast;
+
+import java.util.List;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import org.junit.Test;
+
+/**
+ *
+ * @author jimmy
+ */
+public class AstUtilTest {
+
+    @Test
+    public void testGetClafers() {
+        AstModel model = Asts.newModel();
+        AstAbstractClafer animal = model.addAbstract("Animal");
+        AstAbstractClafer limb = animal.addAbstractChild("Limb");
+        AstConcreteClafer head = animal.addChild("Head");
+        AstConcreteClafer dog = model.addChild("Dog").extending(animal);
+        AstConcreteClafer leg = dog.addChild("Leg").extending(limb);
+        AstConcreteClafer tail = dog.addChild("Tail");
+
+        List<AstClafer> clafers = AstUtil.getClafers(model);
+        assertEquals(9, clafers.size());
+        assertTrue(clafers.contains(model.getAbstractRoot()));
+        assertTrue(clafers.contains(model.getRoot()));
+        assertTrue(clafers.contains(model.getTypeRoot()));
+        assertTrue(clafers.contains(animal));
+        assertTrue(clafers.contains(limb));
+        assertTrue(clafers.contains(head));
+        assertTrue(clafers.contains(dog));
+        assertTrue(clafers.contains(leg));
+        assertTrue(clafers.contains(tail));
+    }
+}

--- a/src/test/java/org/clafer/ast/analysis/CardAnalyzerTest.java
+++ b/src/test/java/org/clafer/ast/analysis/CardAnalyzerTest.java
@@ -34,7 +34,9 @@ public class CardAnalyzerTest {
         globalCards.put(digit, new Card(100, 200));
         globalCards.put(parrot, new Card(3, 4));
         globalCards.put(beak, new Card(1, 15));
-        globalCards.put(model.getTypeHierarchyRoot(), new Card(1, 1));
+        globalCards.put(animal.getSuperClafer(), new Card(1, 1));
+        globalCards.put(model.getAbstractRoot(), new Card(1, 1));
+        globalCards.put(model.getRoot(), new Card(1, 1));
 
         Analysis analysis =
                 new CardAnalyzer().analyze(

--- a/src/test/java/org/clafer/ast/analysis/ScopeAnalyzerTest.java
+++ b/src/test/java/org/clafer/ast/analysis/ScopeAnalyzerTest.java
@@ -36,8 +36,7 @@ public class ScopeAnalyzerTest {
         scope.put(robin, 3);
 
         Map<AstClafer, Card> globalCards = new HashMap<>();
-        globalCards.put(model, new Card(1, 1));
-        globalCards.put(model.getTypeHierarchyRoot(), new Card(1, 1));
+        globalCards.put(model.getRoot(), new Card(1, 1));
         globalCards.put(object, new Card(3));
         globalCards.put(id, new Card(0, 2));
         globalCards.put(hash, new Card(7));

--- a/src/test/java/org/clafer/ast/analysis/TypeAnalyzerTest.java
+++ b/src/test/java/org/clafer/ast/analysis/TypeAnalyzerTest.java
@@ -168,7 +168,7 @@ public class TypeAnalyzerTest {
     /**
      * <pre>
      * A
-     * [ some A.parent ]
+     * [ some A.parent.parent ]
      * </pre>
      */
     @Test(expected = TypeException.class)
@@ -176,7 +176,7 @@ public class TypeAnalyzerTest {
         AstModel model = newModel();
 
         AstConcreteClafer a = model.addChild("a").withCard(Mandatory);
-        model.addConstraint(some(joinParent(global(a))));
+        model.addConstraint(some(joinParent(joinParent(global(a)))));
 
         Analysis.analyze(model, Scope.defaultScope(1), new TypeAnalyzer());
     }

--- a/src/test/java/org/clafer/choco/constraint/ArcConsistentCheck.java
+++ b/src/test/java/org/clafer/choco/constraint/ArcConsistentCheck.java
@@ -20,27 +20,18 @@ public class ArcConsistentCheck implements IMonitorDownBranch, IMonitorContradic
     }
 
     @Override
-    public void beforeDownLeftBranch() {
-        Variable[] vars = solver.getVars();
-        lastDecision.setLength(0);
-        lastDecision.append("Decision: ").append(solver.getSearchLoop().getLastDecision()).append('\n');
-        lastDecision.append("Variables: ");
-        for (Variable var : vars) {
-            lastDecision.append(var).append(' ');
+    public void beforeDownBranch(boolean left) {
+        if (left) {
+            Variable[] vars = solver.getVars();
+            lastDecision.setLength(0);
+            lastDecision.append("Decision: ").append(solver.getSearchLoop().getLastDecision()).append('\n');
+            lastDecision.append("Variables: ");
+            for (Variable var : vars) {
+                lastDecision.append(var).append(' ');
+            }
+        } else {
+            lastDecision.setLength(0);
         }
-    }
-
-    @Override
-    public void afterDownLeftBranch() {
-    }
-
-    @Override
-    public void beforeDownRightBranch() {
-        lastDecision.setLength(0);
-    }
-
-    @Override
-    public void afterDownRightBranch() {
     }
 
     @Override

--- a/src/test/java/org/clafer/domain/DomainTheory.java
+++ b/src/test/java/org/clafer/domain/DomainTheory.java
@@ -230,6 +230,12 @@ public class DomainTheory {
     }
 
     @Theory
+    public void intersectionUnboundedIsIdentity(Domain d) {
+        Domain intersection = d.intersection(Domains.Unbounded);
+        assertSame(intersection, d);
+    }
+
+    @Theory
     public void unionAxiom(Domain d1, Domain d2) {
         Domain union = d1.union(d2);
         for (int i : union.getValues()) {

--- a/src/test/java/org/clafer/graph/TopologicalSortTest.java
+++ b/src/test/java/org/clafer/graph/TopologicalSortTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  */
 public class TopologicalSortTest {
 
-    private static <T> HashSet<T> set(T... items) {
+    private static <T> HashSet<Character> set(Character... items) {
         return new HashSet<>(Arrays.asList(items));
     }
 

--- a/src/test/java/org/clafer/instance/InstanceModelTest.java
+++ b/src/test/java/org/clafer/instance/InstanceModelTest.java
@@ -23,6 +23,6 @@ public class InstanceModelTest {
         InstanceClafer featureInstance = new InstanceClafer(feature, 0, null, costInstance);
         InstanceModel modelInstance = new InstanceModel(featureInstance);
 
-        assertEquals("Feature$0\n  Cost$0 = 3\n", modelInstance.toString());
+        assertEquals("Feature\n  Cost -> 3\n", modelInstance.toString());
     }
 }

--- a/src/test/java/org/clafer/math/RationalTheory.java
+++ b/src/test/java/org/clafer/math/RationalTheory.java
@@ -1,0 +1,26 @@
+package org.clafer.math;
+
+import static org.junit.Assert.assertTrue;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+/**
+ *
+ * @author jimmy
+ */
+@RunWith(Theories.class)
+public class RationalTheory {
+
+    @DataPoints
+    public static final Rational[] rationals = new Rational[]{
+        new Rational(-1), new Rational(0), new Rational(1),
+        new Rational(1, 2), new Rational(3, 2), new Rational(4, 3)
+    };
+
+    @Theory
+    public void testCeilGreaterEqualFloor(Rational r) {
+        assertTrue(r.ceil() >= r.floor());
+    }
+}

--- a/src/test/java/org/clafer/test/TestUtil.java
+++ b/src/test/java/org/clafer/test/TestUtil.java
@@ -238,7 +238,7 @@ public class TestUtil {
 
     public static IrStringVar randIrStringVar() {
         String name = "String" + varCount++;
-        IrIntVar length = randIrIntVar("Int", 0, 4);
+        IrIntVar length = randIrIntVar("|" + name + "|", 0, 4);
         IrIntVar[] chars = new IrIntVar[length.getDomain().getHighBound()];
         for (int i = 0; i < chars.length; i++) {
             Domain domain = randNonEmptyDomain('a', 'c');
@@ -251,7 +251,7 @@ public class TestUtil {
 
     public static IrStringVar randNonEmptyIrStringVar() {
         String name = "String" + varCount++;
-        IrIntVar length = randIrIntVar("Int", 1, 4);
+        IrIntVar length = randIrIntVar("|" + name + "|", 1, 4);
         IrIntVar[] chars = new IrIntVar[length.getDomain().getHighBound()];
         for (int i = 0; i < chars.length; i++) {
             Domain domain = randNonEmptyDomain('a', 'c');

--- a/src/test/resources/assert-positive/nestedInheritanceWithReference.js
+++ b/src/test/resources/assert-positive/nestedInheritanceWithReference.js
@@ -1,0 +1,26 @@
+scope({c0_Connection:5, c0_System:2, c0_connections:10});
+defaultScope(1);
+intRange(-8, 7);
+stringLength(16);
+
+c0_System = Abstract("c0_System");
+c0_Connection = c0_System.addAbstractChild("c0_Connection");
+c0_connections = c0_System.addChild("c0_connections");
+c0_SystemX = Clafer("c0_SystemX").withCard(1, 1);
+c0_con1 = c0_SystemX.addChild("c0_con1").withCard(1, 1);
+c0_con2 = c0_SystemX.addChild("c0_con2").withCard(1, 1);
+c0_SystemY = Clafer("c0_SystemY").withCard(1, 1);
+c0_con3 = c0_SystemY.addChild("c0_con3").withCard(1, 1);
+c0_con4 = c0_SystemY.addChild("c0_con4").withCard(1, 1);
+c0_con5 = c0_SystemY.addChild("c0_con5").withCard(1, 1);
+c0_connections.refToUnique(c0_Connection);
+c0_System.addConstraint(equal(joinRef(join($this(), c0_connections)), join($this(), c0_Connection)));
+c0_SystemX.extending(c0_System);
+c0_con1.extending(c0_Connection);
+c0_con2.extending(c0_Connection);
+assert(equal(joinRef(join(global(c0_SystemX), c0_connections)), union(join(global(c0_SystemX), c0_con1), join(global(c0_SystemX), c0_con2))));
+c0_SystemY.extending(c0_System);
+c0_con3.extending(c0_Connection);
+c0_con4.extending(c0_Connection);
+c0_con5.extending(c0_Connection);
+assert(equal(joinRef(join(global(c0_SystemY), c0_connections)), union(union(join(global(c0_SystemY), c0_con3), join(global(c0_SystemY), c0_con4)), join(global(c0_SystemY), c0_con5))));

--- a/src/test/resources/solve-positive/toeklk.js
+++ b/src/test/resources/solve-positive/toeklk.js
@@ -1,0 +1,24 @@
+scope({c0_HWComponent:2, c0_Platform:3, c0_hwComponents:6, c0_platforms:3, c0_price:3, c1_price:2});
+defaultScope(1);
+intRange(0, 64);
+stringLength(16);
+
+c0_Platform = Abstract("c0_Platform");
+c0_HWComponent = Abstract("c0_HWComponent");
+c0_Deployment = Abstract("c0_Deployment");
+c0_price = c0_Platform.addChild("c0_price").withCard(1, 1);
+c0_hwComponents = c0_Platform.addChild("c0_hwComponents").withCard(1, 2);
+c1_price = c0_HWComponent.addChild("c1_price").withCard(1, 1);
+c2_price = c0_Deployment.addChild("c2_price").withCard(1, 1);
+c0_platforms = c0_Deployment.addChild("c0_platforms").withCard(2, 3).extending(c0_Platform);
+c0_CAN = Clafer("c0_CAN").withCard(1, 1).extending(c0_HWComponent);
+c0_DO = Clafer("c0_DO").withCard(1, 1).extending(c0_HWComponent);
+c0_D1 = Clafer("c0_D1").withCard(1, 1).extending(c0_Deployment);
+c0_price.refTo(Int);
+c0_hwComponents.refToUnique(c0_HWComponent);
+c1_price.refTo(Int);
+c2_price.refTo(Int);
+c0_Platform.addConstraint(implies(some(join($this(), c0_price)), equal(joinRef(join($this(), c0_price)), sum(join(joinRef(join($this(), c0_hwComponents)), c1_price)))));
+c0_Deployment.addConstraint(implies(some(join($this(), c2_price)), equal(joinRef(join($this(), c2_price)), add(mul(card(join($this(), c0_platforms)), constant(10)), sum(join(join($this(), c0_platforms), c0_price))))));
+c0_CAN.addConstraint(equal(joinRef(join($this(), c1_price)), constant(10)));
+c0_DO.addConstraint(equal(joinRef(join($this(), c1_price)), constant(2)));


### PR DESCRIPTION
* Port to latest Choco3 version 3.3.3
* Support nested abstract clafers
* Added API for specifying ordering of clafers by giving priority `branchingPriority([[a,b], [c,d], [e]]);`
* Improved performance
* Improved pretty printing of instances to harmonize with ClaferIG
* Fixed multiplication/division and overflows handling
* Fixed handling of zeroes in division